### PR TITLE
Add Plots recipe

### DIFF
--- a/src/Plotsrecipe.jl
+++ b/src/Plotsrecipe.jl
@@ -34,7 +34,7 @@ function shapefile_coords{T<:Shapefile.ESRIShape}(polys::AbstractMatrix{T})
     end
 end
 
-@recipe f(poly::Shapefile.ESRIShape) = (seriestype --> :shape; shapefile_coords(poly))
-@recipe f{T<:Shapefile.ESRIShape}(polys::AbstractVector{T}) = (seriestype --> :shape; shapefile_coords(polys))
-@recipe f{T<:Shapefile.ESRIShape}(polys::AbstractMatrix{T}) = (seriestype --> :shape; shapefile_coords(polys))
+@recipe f(poly::Shapefile.ESRIShape) = (seriestype --> :shape; linecolor --> :black; shapefile_coords(poly))
+@recipe f{T<:Shapefile.ESRIShape}(polys::AbstractVector{T}) = (seriestype --> :shape; linecolor --> :black; shapefile_coords(polys))
+@recipe f{T<:Shapefile.ESRIShape}(polys::AbstractMatrix{T}) = (seriestype --> :shape; linecolor --> :black; shapefile_coords(polys))
 @recipe f{T<:Shapefile.Handle}(::Type{T}, handle::T) = handle.shapes

--- a/src/Plotsrecipe.jl
+++ b/src/Plotsrecipe.jl
@@ -1,4 +1,4 @@
-import RecipesBase
+using RecipesBase
 
 function shapefile_coords(poly::Shapefile.ESRIShape)
     start_indices = poly.parts+1

--- a/src/Plotsrecipe.jl
+++ b/src/Plotsrecipe.jl
@@ -1,0 +1,2 @@
+import RecipesBase
+import Plots: Shape

--- a/src/Plotsrecipe.jl
+++ b/src/Plotsrecipe.jl
@@ -1,6 +1,5 @@
 import RecipesBase
 
-using RecipesBase
 function shapefile_coords(poly::Shapefile.ESRIShape)
     start_indices = poly.parts+1
     end_indices = vcat(poly.parts[2:end], length(poly.points))
@@ -38,4 +37,4 @@ end
 @recipe f(poly::Shapefile.ESRIShape) = (seriestype --> :shape; shapefile_coords(poly))
 @recipe f{T<:Shapefile.ESRIShape}(polys::AbstractVector{T}) = (seriestype --> :shape; shapefile_coords(polys))
 @recipe f{T<:Shapefile.ESRIShape}(polys::AbstractMatrix{T}) = (seriestype --> :shape; shapefile_coords(polys))
-@recipe f{T<:Shapefile.Handle}(::Type{T}, handle::T) = handle.shapes'
+@recipe f{T<:Shapefile.Handle}(::Type{T}, handle::T) = handle.shapes

--- a/src/Plotsrecipe.jl
+++ b/src/Plotsrecipe.jl
@@ -1,2 +1,41 @@
 import RecipesBase
-import Plots: Shape
+
+using RecipesBase
+function shapefile_coords(poly::Shapefile.ESRIShape)
+    start_indices = poly.parts+1
+    end_indices = vcat(poly.parts[2:end], length(poly.points))
+    x, y = zeros(0), zeros(0)
+    for (si,ei) in zip(start_indices, end_indices)
+        push!(x, NaN)
+        push!(y, NaN)
+        for pt in poly.points[si:ei]
+            push!(x, pt.x)
+            push!(y, pt.y)
+        end
+    end
+    x, y
+end
+
+function shapefile_coords{T<:Shapefile.ESRIShape}(polys::AbstractVector{T})
+    x, y = zeros(0), zeros(0)
+    for poly in polys
+        xpart, ypart = shapefile_coords(poly)
+        append!(x, xpart)
+        append!(y, ypart)
+    end
+    x, y
+end
+
+function shapefile_coords{T<:Shapefile.ESRIShape}(polys::AbstractMatrix{T})
+    x, y = [], []
+    for c in 1:size(polys,2)
+        xy = shapefile_coords(vec(polys[:,c]))
+        push!(x, xy[1])
+        push!(y, xy[2])
+    end
+end
+
+@recipe f(poly::Shapefile.ESRIShape) = (seriestype --> :shape; shapefile_coords(poly))
+@recipe f{T<:Shapefile.ESRIShape}(polys::AbstractVector{T}) = (seriestype --> :shape; shapefile_coords(polys))
+@recipe f{T<:Shapefile.ESRIShape}(polys::AbstractMatrix{T}) = (seriestype --> :shape; shapefile_coords(polys))
+@recipe f{T<:Shapefile.Handle}(::Type{T}, handle::T) = handle.shapes'

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -2,29 +2,29 @@ module Shapefile
     import Base: read, show, +, /, ./
 
     export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
- 
+
     type Rect{T}
         top::T
         left::T
         bottom::T
         right::T
     end
- 
+
     abstract ESRIShape
- 
+
     type NullShape <: ESRIShape
     end
- 
+
     type Interval{T}
         left::T
         right::T
     end
- 
+
     type Point{T} <: ESRIShape
         x::T
         y::T
     end
- 
+
     +{T}(a::Point{T},b::Point{T}) = Point{T}(a.x+b.x,a.y+b.y)
     /{T}(a::Point{T},val::Real) = Point{T}(a.x/val,a.y/val)
     ./{T}(a::Point{T},val::Real) = Point{T}(a.x./val,a.y./val)
@@ -41,7 +41,7 @@ module Shapefile
         z::T
         m::M # measure
     end
- 
+
     type Polyline{T} <: ESRIShape
         MBR::Rect{T}
         parts::Vector{Int32}
@@ -62,13 +62,13 @@ module Shapefile
         zvalues::Vector{T}
         measures::Vector{M}
     end
- 
+
     type Polygon{T} <: ESRIShape
         MBR::Rect{T}
         parts::Vector{Int32}
         points::Vector{Point{T}}
     end
- 
+
     show{T}(io::IO,p::Polygon{T}) = print(io,"Polygon(",length(p.points)," ",T," Points)")
 
     type PolygonM{T,M} <: ESRIShape
@@ -85,7 +85,7 @@ module Shapefile
         zvalues::Vector{T}
         measures::Vector{M}
     end
- 
+
     type MultiPoint{T} <: ESRIShape
         MBR::Rect{T}
         points::Vector{Point{T}}
@@ -123,7 +123,7 @@ module Shapefile
         mrange::Interval{Float64}
         shapes::Vector{ESRIShape}
     end
- 
+
     function read{T}(io::IO,::Type{Rect{T}})
         minx = read(io,T)
         miny = read(io,T)
@@ -133,7 +133,7 @@ module Shapefile
     end
 
     read(io::IO,::Type{NullShape}) = NullShape()
- 
+
     function read{T}(io::IO,::Type{Point{T}})
         x = read(io,T)
         y = read(io,T)
@@ -154,7 +154,7 @@ module Shapefile
         m = read(io,M)
         PointZ{T,M}(x,y,z,m)
     end
- 
+
     function read{T}(io::IO,::Type{Polyline{T}})
         box = read(io,Rect{T})
         numparts = read(io,Int32)
@@ -199,7 +199,7 @@ module Shapefile
         read!(io, measures)
         PolylineZ{T,M}(box,parts,points,zvalues,measures)
     end
- 
+
     function read{T}(io::IO,::Type{Polygon{T}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
@@ -301,7 +301,7 @@ module Shapefile
         # read!(io, measures)
         MultiPatch{T,M}(box,parts,parttypes,points,zvalues) #,measures)
     end
- 
+
     function read(io::IO,::Type{ESRIShape})
         num = bswap(read(io,Int32))
         rlength = bswap(read(io,Int32))
@@ -338,7 +338,7 @@ module Shapefile
             error("Unknown shape type $shapeType")
         end
     end
- 
+
     function read(io::IO,::Type{Handle})
         code = bswap(read(io,Int32))
         read(io,Int32,5)
@@ -357,7 +357,8 @@ module Shapefile
         end
         file
     end
-    
+
     #If Compose.jl is present, define useful interconversion functions
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")
+    isdefined(:Plots) && isa(Plots, Module) && include("Plotsrecipe.jl")
 end # module

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -361,4 +361,5 @@ module Shapefile
     #If Compose.jl is present, define useful interconversion functions
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")
     include("Plotsrecipe.jl")
+
 end # module

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,7 +1,7 @@
 module Shapefile
     import Base: read, show, +, /, ./
 
-    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient, apply_recipe
+    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
 
     type Rect{T}
         top::T
@@ -360,6 +360,6 @@ module Shapefile
 
     #If Compose.jl is present, define useful interconversion functions
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")
-    include("Plotsrecipe.jl")
+    isdefined(:RecipesBase) && is(RecipesBase, Module) && include("Plotsrecipe.jl")
 
 end # module

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,7 +1,7 @@
 module Shapefile
     import Base: read, show, +, /, ./
 
-    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient, f
+    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient, apply_recipe
 
     type Rect{T}
         top::T

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,7 +1,7 @@
 module Shapefile
     import Base: read, show, +, /, ./
 
-    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
+    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient, f
 
     type Rect{T}
         top::T
@@ -360,5 +360,5 @@ module Shapefile
 
     #If Compose.jl is present, define useful interconversion functions
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")
-    isdefined(:Plots) && isa(Plots, Module) && include("Plotsrecipe.jl")
+    include("Plotsrecipe.jl")
 end # module


### PR DESCRIPTION
WIP - work in progress

Adds plotting functionality to shapefiles by a recipe for the Plots.jl package. A lot of the code in the PR is written by Tom Breloff (the owner of Plots.jl).
Right now only works for Polygon shapefiles (type 5) but I will expand this if you are interested.

An example that works:
```
# load the packages
using Shapefile, Plots
pyplot()

# get an example shapefile
using Requests #Just to get the example shapefile
tmp = get("https://github.com/nvkelso/natural-earth-vector/raw/master/110m_physical/ne_110m_land.shp")
save(tmp, "tmp.shp")
shp = open("tmp.shp") do fd
    read(fd, Shapefile.Handle)
end;

#plot it 
plot(shp, color = :green, aspect_ratio = 1, legend = false)