### PR TITLE
Allow precompilation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.3
+julia 0.5

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,30 +1,32 @@
+__precompile__()
+
 module Shapefile
     import Base: read, show, +, /, ./
 
     export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
- 
+
     type Rect{T}
         top::T
         left::T
         bottom::T
         right::T
     end
- 
+
     abstract ESRIShape
- 
+
     type NullShape <: ESRIShape
     end
- 
+
     type Interval{T}
         left::T
         right::T
     end
- 
+
     type Point{T} <: ESRIShape
         x::T
         y::T
     end
- 
+
     +{T}(a::Point{T},b::Point{T}) = Point{T}(a.x+b.x,a.y+b.y)
     /{T}(a::Point{T},val::Real) = Point{T}(a.x/val,a.y/val)
     ./{T}(a::Point{T},val::Real) = Point{T}(a.x./val,a.y./val)
@@ -41,7 +43,7 @@ module Shapefile
         z::T
         m::M # measure
     end
- 
+
     type Polyline{T} <: ESRIShape
         MBR::Rect{T}
         parts::Vector{Int32}
@@ -62,13 +64,13 @@ module Shapefile
         zvalues::Vector{T}
         measures::Vector{M}
     end
- 
+
     type Polygon{T} <: ESRIShape
         MBR::Rect{T}
         parts::Vector{Int32}
         points::Vector{Point{T}}
     end
- 
+
     show{T}(io::IO,p::Polygon{T}) = print(io,"Polygon(",length(p.points)," ",T," Points)")
 
     type PolygonM{T,M} <: ESRIShape
@@ -85,7 +87,7 @@ module Shapefile
         zvalues::Vector{T}
         measures::Vector{M}
     end
- 
+
     type MultiPoint{T} <: ESRIShape
         MBR::Rect{T}
         points::Vector{Point{T}}
@@ -123,7 +125,7 @@ module Shapefile
         mrange::Interval{Float64}
         shapes::Vector{ESRIShape}
     end
- 
+
     function read{T}(io::IO,::Type{Rect{T}})
         minx = read(io,T)
         miny = read(io,T)
@@ -133,7 +135,7 @@ module Shapefile
     end
 
     read(io::IO,::Type{NullShape}) = NullShape()
- 
+
     function read{T}(io::IO,::Type{Point{T}})
         x = read(io,T)
         y = read(io,T)
@@ -154,7 +156,7 @@ module Shapefile
         m = read(io,M)
         PointZ{T,M}(x,y,z,m)
     end
- 
+
     function read{T}(io::IO,::Type{Polyline{T}})
         box = read(io,Rect{T})
         numparts = read(io,Int32)
@@ -199,7 +201,7 @@ module Shapefile
         read!(io, measures)
         PolylineZ{T,M}(box,parts,points,zvalues,measures)
     end
- 
+
     function read{T}(io::IO,::Type{Polygon{T}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
@@ -301,7 +303,7 @@ module Shapefile
         # read!(io, measures)
         MultiPatch{T,M}(box,parts,parttypes,points,zvalues) #,measures)
     end
- 
+
     function read(io::IO,::Type{ESRIShape})
         num = bswap(read(io,Int32))
         rlength = bswap(read(io,Int32))
@@ -338,7 +340,7 @@ module Shapefile
             error("Unknown shape type $shapeType")
         end
     end
- 
+
     function read(io::IO,::Type{Handle})
         code = bswap(read(io,Int32))
         read(io,Int32,5)
@@ -357,7 +359,7 @@ module Shapefile
         end
         file
     end
-    
+
     #If Compose.jl is present, define useful interconversion functions
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,8 @@ for test_file in readdir(joinpath(dirname(@__FILE__), "shapelib_testcases"))
             read(fd,Shapefile.Handle)
         end
         shapes = unique(map(typeof,shp.shapes))
-        @fact length(shapes) => 1
+        @fact length(shapes) --> 1
         push!(seen_types, shapes[1])
     end
 end
-@fact seen_types => test_types
+@fact seen_types --> test_types


### PR DESCRIPTION
This PR turns on precompilation, which appears to work fine (all tests pass).

Additionally, this PR bumps the minimum Julia version required to current
release (0.5); although it is an overly conservative requirement, I don't think
it's very likely that many people will continue to bump into downstream
precompilation problems (like JuliaPlots/PlotRecipes.jl#10) on 0.4 or earlier.

Also, modernize deprecated FactCheck syntax in tests.