### PR TITLE
Fix deprecation warnings on julia v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("Shapefile"; coverage=true)'
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("Shapefile"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-GeoInterface
+GeoInterface 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-GeoInterface 0.2
+GeoInterface 0.2.1

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -338,6 +338,8 @@ module Shapefile
     end
 
     include("geo_interface.jl")
-    #If Compose.jl is present, define useful interconversion functions
+    # If Compose.jl is present, define useful interconversion functions.
+    # Note that in julia v0.6 this is never true, it should be isdefined(Main, :Compose).
+    # This does't interact well with precompilation.
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")
 end # module

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -6,27 +6,27 @@ module Shapefile
     import Base: read, show, +, /, ./
 
     export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
- 
+
     type Rect{T}
         top::T
         left::T
         bottom::T
         right::T
     end
- 
+
     type NullShape <: GeoInterface.AbstractGeometry
     end
- 
+
     type Interval{T}
         left::T
         right::T
     end
- 
+
     type Point{T} <: GeoInterface.AbstractPoint
         x::T
         y::T
     end
- 
+
     +{T}(a::Point{T},b::Point{T}) = Point{T}(a.x+b.x,a.y+b.y)
     /{T}(a::Point{T},val::Real) = Point{T}(a.x/val,a.y/val)
     ./{T}(a::Point{T},val::Real) = Point{T}(a.x./val,a.y./val)
@@ -43,7 +43,7 @@ module Shapefile
         z::T
         m::M # measure
     end
- 
+
     type Polyline{T} <: GeoInterface.AbstractMultiLineString
         MBR::Rect{T}
         parts::Vector{Int32}
@@ -64,13 +64,13 @@ module Shapefile
         zvalues::Vector{T}
         measures::Vector{M}
     end
- 
+
     type Polygon{T} <: GeoInterface.AbstractMultiPolygon
         MBR::Rect{T}
         parts::Vector{Int32}
         points::Vector{Point{T}}
     end
- 
+
     show{T}(io::IO,p::Polygon{T}) = print(io,"Polygon(",length(p.points)," ",T," Points)")
 
     type PolygonM{T,M} <: GeoInterface.AbstractMultiPolygon
@@ -87,7 +87,7 @@ module Shapefile
         zvalues::Vector{T}
         measures::Vector{M}
     end
- 
+
     type MultiPoint{T} <: GeoInterface.AbstractMultiPoint
         MBR::Rect{T}
         points::Vector{Point{T}}
@@ -142,7 +142,7 @@ module Shapefile
         mrange::Interval{Float64}
         shapes::Vector{T}
     end
- 
+
     function read{T}(io::IO,::Type{Rect{T}})
         minx = read(io,T)
         miny = read(io,T)
@@ -152,7 +152,7 @@ module Shapefile
     end
 
     read(io::IO,::Type{NullShape}) = NullShape()
- 
+
     function read{T}(io::IO,::Type{Point{T}})
         x = read(io,T)
         y = read(io,T)
@@ -173,14 +173,14 @@ module Shapefile
         m = read(io,M)
         PointZ{T,M}(x,y,z,m)
     end
- 
+
     function read{T}(io::IO,::Type{Polyline{T}})
         box = read(io,Rect{T})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
         Polyline{T}(box,parts,points)
     end
@@ -189,13 +189,13 @@ module Shapefile
         box = read(io,Rect{T})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        mrange = Array(M,2)
+        mrange = Array{M}(2)
         read!(io, mrange)
-        measures = Array(M,numpoints)
+        measures = Array{M}(numpoints)
         read!(io, measures)
         PolylineM{T,M}(box,parts,points,measures)
     end
@@ -204,28 +204,28 @@ module Shapefile
         box = read(io,Rect{T})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        zrange = Array(T,2)
+        zrange = Array{T}(2)
         read!(io, zrange)
-        zvalues = Array(T,numpoints)
+        zvalues = Array{T}(numpoints)
         read!(io, zvalues)
-        mrange = Array(M,2)
+        mrange = Array{M}(2)
         read!(io, mrange)
-        measures = Array(M,numpoints)
+        measures = Array{M}(numpoints)
         read!(io, measures)
         PolylineZ{T,M}(box,parts,points,zvalues,measures)
     end
- 
+
     function read{T}(io::IO,::Type{Polygon{T}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
         Polygon{T}(box,parts,points)
     end
@@ -234,13 +234,13 @@ module Shapefile
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        mrange = Array(M,2)
+        mrange = Array{M}(2)
         read!(io, mrange)
-        measures = Array(M,numpoints)
+        measures = Array{M}(numpoints)
         read!(io, measures)
         PolygonM{T,M}(box,parts,points,measures)
     end
@@ -249,17 +249,17 @@ module Shapefile
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        zrange = Array(T,2)
+        zrange = Array{T}(2)
         read!(io, zrange)
-        zvalues = Array(T,numpoints)
+        zvalues = Array{T}(numpoints)
         read!(io, zvalues)
-        mrange = Array(M,2)
+        mrange = Array{M}(2)
         read!(io, mrange)
-        measures = Array(M,numpoints)
+        measures = Array{M}(numpoints)
         read!(io, measures)
         PolygonZ{T,M}(box,parts,points,zvalues,measures)
     end
@@ -267,7 +267,7 @@ module Shapefile
     function read{T}(io::IO,::Type{MultiPoint{T}})
         box = read(io,Rect{Float64})
         numpoints = read(io,Int32)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
         MultiPoint{T}(box,points)
     end
@@ -275,11 +275,11 @@ module Shapefile
     function read{T,M}(io::IO,::Type{MultiPointM{T,M}})
         box = read(io,Rect{Float64})
         numpoints = read(io,Int32)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        mrange = Array(M,2)
+        mrange = Array{M}(2)
         read!(io, mrange)
-        measures = Array(M,numpoints)
+        measures = Array{M}(numpoints)
         read!(io, measures)
         MultiPointM{T,M}(box,points,measures)
     end
@@ -287,15 +287,15 @@ module Shapefile
     function read{T,M}(io::IO,::Type{MultiPointZ{T,M}})
         box = read(io,Rect{Float64})
         numpoints = read(io,Int32)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        zrange = Array(T,2)
+        zrange = Array{T}(2)
         read!(io, zrange)
-        zvalues = Array(T,numpoints)
+        zvalues = Array{T}(numpoints)
         read!(io, zvalues)
-        mrange = Array(M,2)
+        mrange = Array{M}(2)
         read!(io, mrange)
-        measures = Array(M,numpoints)
+        measures = Array{M}(numpoints)
         read!(io, measures)
         MultiPointZ{T,M}(box,points,zvalues,measures)
     end
@@ -304,23 +304,23 @@ module Shapefile
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
-        parts = Array(Int32,numparts)
+        parts = Array{Int32}(numparts)
         read!(io, parts)
-        parttypes = Array(Int32,numparts)
+        parttypes = Array{Int32}(numparts)
         read!(io, parttypes)
-        points = Array(Point{T},numpoints)
+        points = Array{Point{T}}(numpoints)
         read!(io, points)
-        zrange = Array(T,2)
+        zrange = Array{T}(2)
         read!(io, zrange)
-        zvalues = Array(T,numpoints)
+        zvalues = Array{T}(numpoints)
         read!(io, zvalues)
-        # mrange = Array(M,2)
+        # mrange = Array{M}(2)
         # read!(io, mrange)
-        # measures = Array(M,numpoints)
+        # measures = Array{M}(numpoints)
         # read!(io, measures)
         MultiPatch{T,M}(box,parts,parttypes,points,zvalues) #,measures)
     end
- 
+
     function read(io::IO,::Type{Handle})
         code = bswap(read(io,Int32))
         read(io,Int32,5)
@@ -333,7 +333,7 @@ module Shapefile
         mmin = read(io,Float64)
         mmax = read(io,Float64)
         jltype = SHAPETYPE[shapeType]
-        shapes = Array(jltype,0)
+        shapes = Array{jltype}(0)
         file = Handle(code,fileSize,version,shapeType,MBR,Interval(zmin,zmax),Interval(mmin,mmax),shapes)
         while(!eof(io))
             num = bswap(read(io,Int32))
@@ -343,7 +343,7 @@ module Shapefile
         end
         file
     end
-    
+
     include("geo_interface.jl")
     #If Compose.jl is present, define useful interconversion functions
     isdefined(:Compose) && isa(Compose, Module) && include("compose.jl")

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -3,7 +3,6 @@ __precompile__()
 module Shapefile
 
     import GeoInterface
-    import Base: read, show, +, /
 
     export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
 
@@ -26,9 +25,6 @@ module Shapefile
         x::T
         y::T
     end
-
-    +{T}(a::Point{T},b::Point{T}) = Point{T}(a.x+b.x,a.y+b.y)
-    /{T}(a::Point{T},val::Real) = Point{T}(a.x/val,a.y/val)
 
     type PointM{T,M} <: GeoInterface.AbstractPoint
         x::T
@@ -70,7 +66,7 @@ module Shapefile
         points::Vector{Point{T}}
     end
 
-    show{T}(io::IO,p::Polygon{T}) = print(io,"Polygon(",length(p.points)," ",T," Points)")
+    Base.show{T}(io::IO,p::Polygon{T}) = print(io,"Polygon(",length(p.points)," ",T," Points)")
 
     type PolygonM{T,M} <: GeoInterface.AbstractMultiPolygon
         MBR::Rect{T}
@@ -142,7 +138,7 @@ module Shapefile
         shapes::Vector{T}
     end
 
-    function read{T}(io::IO,::Type{Rect{T}})
+    function Base.read{T}(io::IO,::Type{Rect{T}})
         minx = read(io,T)
         miny = read(io,T)
         maxx = read(io,T)
@@ -150,22 +146,22 @@ module Shapefile
         Rect{T}(miny,minx,maxy,maxx)
     end
 
-    read(io::IO,::Type{NullShape}) = NullShape()
+    Base.read(io::IO,::Type{NullShape}) = NullShape()
 
-    function read{T}(io::IO,::Type{Point{T}})
+    function Base.read{T}(io::IO,::Type{Point{T}})
         x = read(io,T)
         y = read(io,T)
         Point{T}(x,y)
     end
 
-    function read{T,M}(io::IO,::Type{PointM{T,M}})
+    function Base.read{T,M}(io::IO,::Type{PointM{T,M}})
         x = read(io,T)
         y = read(io,T)
         m = read(io,M)
         PointM{T,M}(x,y,m)
     end
 
-    function read{T,M}(io::IO,::Type{PointZ{T,M}})
+    function Base.read{T,M}(io::IO,::Type{PointZ{T,M}})
         x = read(io,T)
         y = read(io,T)
         z = read(io,T)
@@ -173,7 +169,7 @@ module Shapefile
         PointZ{T,M}(x,y,z,m)
     end
 
-    function read{T}(io::IO,::Type{Polyline{T}})
+    function Base.read{T}(io::IO,::Type{Polyline{T}})
         box = read(io,Rect{T})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -184,7 +180,7 @@ module Shapefile
         Polyline{T}(box,parts,points)
     end
 
-    function read{T,M}(io::IO,::Type{PolylineM{T,M}})
+    function Base.read{T,M}(io::IO,::Type{PolylineM{T,M}})
         box = read(io,Rect{T})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -199,7 +195,7 @@ module Shapefile
         PolylineM{T,M}(box,parts,points,measures)
     end
 
-    function read{T,M}(io::IO,::Type{PolylineZ{T,M}})
+    function Base.read{T,M}(io::IO,::Type{PolylineZ{T,M}})
         box = read(io,Rect{T})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -218,7 +214,7 @@ module Shapefile
         PolylineZ{T,M}(box,parts,points,zvalues,measures)
     end
 
-    function read{T}(io::IO,::Type{Polygon{T}})
+    function Base.read{T}(io::IO,::Type{Polygon{T}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -229,7 +225,7 @@ module Shapefile
         Polygon{T}(box,parts,points)
     end
 
-    function read{T,M}(io::IO,::Type{PolygonM{T,M}})
+    function Base.read{T,M}(io::IO,::Type{PolygonM{T,M}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -244,7 +240,7 @@ module Shapefile
         PolygonM{T,M}(box,parts,points,measures)
     end
 
-    function read{T,M}(io::IO,::Type{PolygonZ{T,M}})
+    function Base.read{T,M}(io::IO,::Type{PolygonZ{T,M}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -263,7 +259,7 @@ module Shapefile
         PolygonZ{T,M}(box,parts,points,zvalues,measures)
     end
 
-    function read{T}(io::IO,::Type{MultiPoint{T}})
+    function Base.read{T}(io::IO,::Type{MultiPoint{T}})
         box = read(io,Rect{Float64})
         numpoints = read(io,Int32)
         points = Array{Point{T}}(numpoints)
@@ -271,7 +267,7 @@ module Shapefile
         MultiPoint{T}(box,points)
     end
 
-    function read{T,M}(io::IO,::Type{MultiPointM{T,M}})
+    function Base.read{T,M}(io::IO,::Type{MultiPointM{T,M}})
         box = read(io,Rect{Float64})
         numpoints = read(io,Int32)
         points = Array{Point{T}}(numpoints)
@@ -283,7 +279,7 @@ module Shapefile
         MultiPointM{T,M}(box,points,measures)
     end
 
-    function read{T,M}(io::IO,::Type{MultiPointZ{T,M}})
+    function Base.read{T,M}(io::IO,::Type{MultiPointZ{T,M}})
         box = read(io,Rect{Float64})
         numpoints = read(io,Int32)
         points = Array{Point{T}}(numpoints)
@@ -299,7 +295,7 @@ module Shapefile
         MultiPointZ{T,M}(box,points,zvalues,measures)
     end
 
-    function read{T,M}(io::IO,::Type{MultiPatch{T,M}})
+    function Base.read{T,M}(io::IO,::Type{MultiPatch{T,M}})
         box = read(io,Rect{Float64})
         numparts = read(io,Int32)
         numpoints = read(io,Int32)
@@ -320,7 +316,7 @@ module Shapefile
         MultiPatch{T,M}(box,parts,parttypes,points,zvalues) #,measures)
     end
 
-    function read(io::IO,::Type{Handle})
+    function Base.read(io::IO,::Type{Handle})
         code = bswap(read(io,Int32))
         read(io,Int32,5)
         fileSize = bswap(read(io,Int32))

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -3,7 +3,7 @@ __precompile__()
 module Shapefile
 
     import GeoInterface
-    import Base: read, show, +, /, ./
+    import Base: read, show, +, /
 
     export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
 
@@ -29,7 +29,6 @@ module Shapefile
 
     +{T}(a::Point{T},b::Point{T}) = Point{T}(a.x+b.x,a.y+b.y)
     /{T}(a::Point{T},val::Real) = Point{T}(a.x/val,a.y/val)
-    ./{T}(a::Point{T},val::Real) = Point{T}(a.x./val,a.y./val)
 
     type PointM{T,M} <: GeoInterface.AbstractPoint
         x::T

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -4,8 +4,6 @@ module Shapefile
 
     import GeoInterface
 
-    export Handle, RGBGradient, LogLinearRGBGradient, LinearRGBGradient
-
     type Rect{T}
         top::T
         left::T

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-FactCheck

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using Shapefile, FactCheck
+using Shapefile
+using Base.Test
 
 test_types = Set([Shapefile.NullShape,
                   Shapefile.Point{Float64},
@@ -33,16 +34,16 @@ coords = Dict{String, Any}(
 
 seen_types = Set(DataType[])
 for test_file in readdir(joinpath(dirname(@__FILE__), "shapelib_testcases"))
-    if test_file[end-3:end] == ".shp"
+    if splitext(test_file)[2] == ".shp"
         shp = open(joinpath(dirname(@__FILE__), "shapelib_testcases", test_file)) do fd
             read(fd,Shapefile.Handle)
         end
         shapes = unique(map(typeof,shp.shapes))
-        @fact length(shapes) --> 1
+        @test length(shapes) == 1
         push!(seen_types, shapes[1])
         if test_file in keys(coords)
-            @fact map(GeoInterface.coordinates, shp.shapes) --> coords[test_file]
+            @test map(GeoInterface.coordinates, shp.shapes) == coords[test_file]
         end
     end
 end
-@fact seen_types --> test_types
+@test seen_types == test_types


### PR DESCRIPTION
Note that this no longer extends `./` from Base, so technically breaking.