### PR TITLE
Update example to v0.7.0/v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Basic example of reading a shapefile from test cases:
 ```julia
 using Shapefile
 
-path = Pkg.dir("Shapefile", "test", "shapelib_testcases", "test.shp")
+path = joinpath(dirname(pathof(Shapefile)),"..","test","shapelib_testcases","test.shp")
 
 handle = open(path, "r") do io
     read(io, Shapefile.Handle)


### PR DESCRIPTION
Fix this deprecation: `Pkg.dir(pkgname, paths...)` is deprecated.