### PR TITLE
allow missing shapes

### DIFF
--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,348 +1,349 @@
 module Shapefile
 
-    import Base.==
-    import GeoInterface
+import Base.==
+import GeoInterface
 
-    mutable struct Rect{T}
-        left::T
-        bottom::T
-        right::T
-        top::T
-    end
+mutable struct Rect{T}
+    left::T
+    bottom::T
+    right::T
+    top::T
+end
 
-    mutable struct NullShape <: GeoInterface.AbstractGeometry
-    end
+mutable struct NullShape <: GeoInterface.AbstractGeometry
+end
 
-    mutable struct Interval{T}
-        left::T
-        right::T
-    end
+mutable struct Interval{T}
+    left::T
+    right::T
+end
 
-    mutable struct Point{T} <: GeoInterface.AbstractPoint
-        x::T
-        y::T
-    end
+mutable struct Point{T} <: GeoInterface.AbstractPoint
+    x::T
+    y::T
+end
 
-    mutable struct PointM{T,M} <: GeoInterface.AbstractPoint
-        x::T
-        y::T
-        m::M # measure
-    end
+mutable struct PointM{T,M} <: GeoInterface.AbstractPoint
+    x::T
+    y::T
+    m::M # measure
+end
 
-    mutable struct PointZ{T,M} <: GeoInterface.AbstractPoint
-        x::T
-        y::T
-        z::T
-        m::M # measure
-    end
+mutable struct PointZ{T,M} <: GeoInterface.AbstractPoint
+    x::T
+    y::T
+    z::T
+    m::M # measure
+end
 
-    mutable struct Polyline{T} <: GeoInterface.AbstractMultiLineString
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        points::Vector{Point{T}}
-    end
+mutable struct Polyline{T} <: GeoInterface.AbstractMultiLineString
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    points::Vector{Point{T}}
+end
 
-    mutable struct PolylineM{T,M} <: GeoInterface.AbstractMultiLineString
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        points::Vector{Point{T}}
-        measures::Vector{M}
-    end
+mutable struct PolylineM{T,M} <: GeoInterface.AbstractMultiLineString
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    points::Vector{Point{T}}
+    measures::Vector{M}
+end
 
-    mutable struct PolylineZ{T,M} <: GeoInterface.AbstractMultiLineString
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        points::Vector{Point{T}}
-        zvalues::Vector{T}
-        measures::Vector{M}
-    end
+mutable struct PolylineZ{T,M} <: GeoInterface.AbstractMultiLineString
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    points::Vector{Point{T}}
+    zvalues::Vector{T}
+    measures::Vector{M}
+end
 
-    mutable struct Polygon{T} <: GeoInterface.AbstractMultiPolygon
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        points::Vector{Point{T}}
-    end
+mutable struct Polygon{T} <: GeoInterface.AbstractMultiPolygon
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    points::Vector{Point{T}}
+end
 
-    Base.show(io::IO,p::Polygon{T}) where {T} = print(io,"Polygon(",length(p.points)," ",T," Points)")
+Base.show(io::IO,p::Polygon{T}) where {T} = print(io,"Polygon(",length(p.points)," ",T," Points)")
 
-    mutable struct PolygonM{T,M} <: GeoInterface.AbstractMultiPolygon
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        points::Vector{Point{T}}
-        measures::Vector{M}
-    end
+mutable struct PolygonM{T,M} <: GeoInterface.AbstractMultiPolygon
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    points::Vector{Point{T}}
+    measures::Vector{M}
+end
 
-    mutable struct PolygonZ{T,M} <: GeoInterface.AbstractMultiPolygon
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        points::Vector{Point{T}}
-        zvalues::Vector{T}
-        measures::Vector{M}
-    end
+mutable struct PolygonZ{T,M} <: GeoInterface.AbstractMultiPolygon
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    points::Vector{Point{T}}
+    zvalues::Vector{T}
+    measures::Vector{M}
+end
 
-    mutable struct MultiPoint{T} <: GeoInterface.AbstractMultiPoint
-        MBR::Rect{T}
-        points::Vector{Point{T}}
-    end
+mutable struct MultiPoint{T} <: GeoInterface.AbstractMultiPoint
+    MBR::Rect{T}
+    points::Vector{Point{T}}
+end
 
-    mutable struct MultiPointM{T,M} <: GeoInterface.AbstractMultiPoint
-        MBR::Rect{T}
-        points::Vector{Point{T}}
-        measures::Vector{M}
-    end
+mutable struct MultiPointM{T,M} <: GeoInterface.AbstractMultiPoint
+    MBR::Rect{T}
+    points::Vector{Point{T}}
+    measures::Vector{M}
+end
 
-    mutable struct MultiPointZ{T,M} <: GeoInterface.AbstractMultiPoint
-        MBR::Rect{T}
-        points::Vector{Point{T}}
-        zvalues::Vector{T}
-        measures::Vector{M}
-    end
+mutable struct MultiPointZ{T,M} <: GeoInterface.AbstractMultiPoint
+    MBR::Rect{T}
+    points::Vector{Point{T}}
+    zvalues::Vector{T}
+    measures::Vector{M}
+end
 
-    mutable struct MultiPatch{T,M} <: GeoInterface.AbstractGeometry
-        MBR::Rect{T}
-        parts::Vector{Int32}
-        parttypes::Vector{Int32}
-        points::Vector{Point{T}}
-        zvalues::Vector{T}
-        # measures::Vector{M} # (optional)
-    end
+mutable struct MultiPatch{T,M} <: GeoInterface.AbstractGeometry
+    MBR::Rect{T}
+    parts::Vector{Int32}
+    parttypes::Vector{Int32}
+    points::Vector{Point{T}}
+    zvalues::Vector{T}
+    # measures::Vector{M} # (optional)
+end
 
-    const SHAPETYPE = Dict{Int32, Any}(
-        0  => NullShape,
-        1  => Point{Float64},
-        3  => Polyline{Float64},
-        5  => Polygon{Float64},
-        8  => MultiPoint{Float64},
-        11 => PointZ{Float64,Float64},
-        13 => PolylineZ{Float64,Float64},
-        15 => PolygonZ{Float64,Float64},
-        18 => MultiPointZ{Float64,Float64},
-        21 => PointM{Float64,Float64},
-        23 => PolylineM{Float64,Float64},
-        25 => PolygonM{Float64,Float64},
-        28 => MultiPointM{Float64,Float64},
-        31 => MultiPatch{Float64,Float64}
-    )
+const SHAPETYPE = Dict{Int32, Any}(
+    0  => NullShape,
+    1  => Point{Float64},
+    3  => Polyline{Float64},
+    5  => Polygon{Float64},
+    8  => MultiPoint{Float64},
+    11 => PointZ{Float64,Float64},
+    13 => PolylineZ{Float64,Float64},
+    15 => PolygonZ{Float64,Float64},
+    18 => MultiPointZ{Float64,Float64},
+    21 => PointM{Float64,Float64},
+    23 => PolylineM{Float64,Float64},
+    25 => PolygonM{Float64,Float64},
+    28 => MultiPointM{Float64,Float64},
+    31 => MultiPatch{Float64,Float64}
+)
 
-    mutable struct Handle{T <: GeoInterface.AbstractGeometry}
-        code::Int32
-        length::Int32
-        version::Int32
-        shapeType::Int32
-        MBR::Rect{Float64}
-        zrange::Interval{Float64}
-        mrange::Interval{Float64}
-        shapes::Vector{T}
-    end
+mutable struct Handle{T <: GeoInterface.AbstractGeometry}
+    code::Int32
+    length::Int32
+    version::Int32
+    shapeType::Int32
+    MBR::Rect{Float64}
+    zrange::Interval{Float64}
+    mrange::Interval{Float64}
+    shapes::Vector{T}
+end
 
-    function Base.read(io::IO,::Type{Rect{T}}) where T
-        minx = read(io,T)
-        miny = read(io,T)
-        maxx = read(io,T)
-        maxy = read(io,T)
-        Rect{T}(minx,miny,maxx,maxy)
-    end
+function Base.read(io::IO,::Type{Rect{T}}) where T
+    minx = read(io,T)
+    miny = read(io,T)
+    maxx = read(io,T)
+    maxy = read(io,T)
+    Rect{T}(minx,miny,maxx,maxy)
+end
 
-    Base.read(io::IO,::Type{NullShape}) = NullShape()
+Base.read(io::IO,::Type{NullShape}) = NullShape()
 
-    function Base.read(io::IO,::Type{Point{T}}) where T
-        x = read(io,T)
-        y = read(io,T)
-        Point{T}(x,y)
-    end
+function Base.read(io::IO,::Type{Point{T}}) where T
+    x = read(io,T)
+    y = read(io,T)
+    Point{T}(x,y)
+end
 
-    function Base.read(io::IO,::Type{PointM{T,M}}) where {T,M}
-        x = read(io,T)
-        y = read(io,T)
-        m = read(io,M)
-        PointM{T,M}(x,y,m)
-    end
+function Base.read(io::IO,::Type{PointM{T,M}}) where {T,M}
+    x = read(io,T)
+    y = read(io,T)
+    m = read(io,M)
+    PointM{T,M}(x,y,m)
+end
 
-    function Base.read(io::IO,::Type{PointZ{T,M}}) where {T,M}
-        x = read(io,T)
-        y = read(io,T)
-        z = read(io,T)
-        m = read(io,M)
-        PointZ{T,M}(x,y,z,m)
-    end
+function Base.read(io::IO,::Type{PointZ{T,M}}) where {T,M}
+    x = read(io,T)
+    y = read(io,T)
+    z = read(io,T)
+    m = read(io,M)
+    PointZ{T,M}(x,y,z,m)
+end
 
-    function Base.read(io::IO,::Type{Polyline{T}}) where T
-        box = read(io,Rect{T})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        Polyline{T}(box,parts,points)
-    end
+function Base.read(io::IO,::Type{Polyline{T}}) where T
+    box = read(io,Rect{T})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    Polyline{T}(box,parts,points)
+end
 
-    function Base.read(io::IO,::Type{PolylineM{T,M}}) where {T,M}
-        box = read(io,Rect{T})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        mrange = Vector{M}(undef, 2)
-        read!(io, mrange)
-        measures = Vector{M}(undef, numpoints)
-        read!(io, measures)
-        PolylineM{T,M}(box,parts,points,measures)
-    end
+function Base.read(io::IO,::Type{PolylineM{T,M}}) where {T,M}
+    box = read(io,Rect{T})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    mrange = Vector{M}(undef, 2)
+    read!(io, mrange)
+    measures = Vector{M}(undef, numpoints)
+    read!(io, measures)
+    PolylineM{T,M}(box,parts,points,measures)
+end
 
-    function Base.read(io::IO,::Type{PolylineZ{T,M}}) where {T,M}
-        box = read(io,Rect{T})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        zrange = Vector{T}(undef, 2)
-        read!(io, zrange)
-        zvalues = Vector{T}(undef, numpoints)
-        read!(io, zvalues)
-        mrange = Vector{M}(undef, 2)
-        read!(io, mrange)
-        measures = Vector{M}(undef, numpoints)
-        read!(io, measures)
-        PolylineZ{T,M}(box,parts,points,zvalues,measures)
-    end
+function Base.read(io::IO,::Type{PolylineZ{T,M}}) where {T,M}
+    box = read(io,Rect{T})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    zrange = Vector{T}(undef, 2)
+    read!(io, zrange)
+    zvalues = Vector{T}(undef, numpoints)
+    read!(io, zvalues)
+    mrange = Vector{M}(undef, 2)
+    read!(io, mrange)
+    measures = Vector{M}(undef, numpoints)
+    read!(io, measures)
+    PolylineZ{T,M}(box,parts,points,zvalues,measures)
+end
 
-    function Base.read(io::IO,::Type{Polygon{T}}) where T
-        box = read(io,Rect{Float64})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        Polygon{T}(box,parts,points)
-    end
+function Base.read(io::IO,::Type{Polygon{T}}) where T
+    box = read(io,Rect{Float64})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    Polygon{T}(box,parts,points)
+end
 
-    function Base.read(io::IO,::Type{PolygonM{T,M}}) where {T,M}
-        box = read(io,Rect{Float64})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        mrange = Vector{M}(undef, 2)
-        read!(io, mrange)
-        measures = Vector{M}(undef, numpoints)
-        read!(io, measures)
-        PolygonM{T,M}(box,parts,points,measures)
-    end
+function Base.read(io::IO,::Type{PolygonM{T,M}}) where {T,M}
+    box = read(io,Rect{Float64})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    mrange = Vector{M}(undef, 2)
+    read!(io, mrange)
+    measures = Vector{M}(undef, numpoints)
+    read!(io, measures)
+    PolygonM{T,M}(box,parts,points,measures)
+end
 
-    function Base.read(io::IO,::Type{PolygonZ{T,M}}) where {T,M}
-        box = read(io,Rect{Float64})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        zrange = Vector{T}(undef, 2)
-        read!(io, zrange)
-        zvalues = Vector{T}(undef, numpoints)
-        read!(io, zvalues)
-        mrange = Vector{M}(undef, 2)
-        read!(io, mrange)
-        measures = Vector{M}(undef, numpoints)
-        read!(io, measures)
-        PolygonZ{T,M}(box,parts,points,zvalues,measures)
-    end
+function Base.read(io::IO,::Type{PolygonZ{T,M}}) where {T,M}
+    box = read(io,Rect{Float64})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    zrange = Vector{T}(undef, 2)
+    read!(io, zrange)
+    zvalues = Vector{T}(undef, numpoints)
+    read!(io, zvalues)
+    mrange = Vector{M}(undef, 2)
+    read!(io, mrange)
+    measures = Vector{M}(undef, numpoints)
+    read!(io, measures)
+    PolygonZ{T,M}(box,parts,points,zvalues,measures)
+end
 
-    function Base.read(io::IO,::Type{MultiPoint{T}}) where T
-        box = read(io,Rect{Float64})
-        numpoints = read(io,Int32)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        MultiPoint{T}(box,points)
-    end
+function Base.read(io::IO,::Type{MultiPoint{T}}) where T
+    box = read(io,Rect{Float64})
+    numpoints = read(io,Int32)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    MultiPoint{T}(box,points)
+end
 
-    function Base.read(io::IO,::Type{MultiPointM{T,M}}) where {T,M}
-        box = read(io,Rect{Float64})
-        numpoints = read(io,Int32)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        mrange = Vector{M}(undef, 2)
-        read!(io, mrange)
-        measures = Vector{M}(undef, numpoints)
-        read!(io, measures)
-        MultiPointM{T,M}(box,points,measures)
-    end
+function Base.read(io::IO,::Type{MultiPointM{T,M}}) where {T,M}
+    box = read(io,Rect{Float64})
+    numpoints = read(io,Int32)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    mrange = Vector{M}(undef, 2)
+    read!(io, mrange)
+    measures = Vector{M}(undef, numpoints)
+    read!(io, measures)
+    MultiPointM{T,M}(box,points,measures)
+end
 
-    function Base.read(io::IO,::Type{MultiPointZ{T,M}}) where {T,M}
-        box = read(io,Rect{Float64})
-        numpoints = read(io,Int32)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        zrange = Vector{T}(undef, 2)
-        read!(io, zrange)
-        zvalues = Vector{T}(undef, numpoints)
-        read!(io, zvalues)
-        mrange = Vector{M}(undef, 2)
-        read!(io, mrange)
-        measures = Vector{M}(undef, numpoints)
-        read!(io, measures)
-        MultiPointZ{T,M}(box,points,zvalues,measures)
-    end
+function Base.read(io::IO,::Type{MultiPointZ{T,M}}) where {T,M}
+    box = read(io,Rect{Float64})
+    numpoints = read(io,Int32)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    zrange = Vector{T}(undef, 2)
+    read!(io, zrange)
+    zvalues = Vector{T}(undef, numpoints)
+    read!(io, zvalues)
+    mrange = Vector{M}(undef, 2)
+    read!(io, mrange)
+    measures = Vector{M}(undef, numpoints)
+    read!(io, measures)
+    MultiPointZ{T,M}(box,points,zvalues,measures)
+end
 
-    function Base.read(io::IO,::Type{MultiPatch{T,M}}) where {T,M}
-        box = read(io,Rect{Float64})
-        numparts = read(io,Int32)
-        numpoints = read(io,Int32)
-        parts = Vector{Int32}(undef, numparts)
-        read!(io, parts)
-        parttypes = Vector{Int32}(undef, numparts)
-        read!(io, parttypes)
-        points = Vector{Point{T}}(undef, numpoints)
-        read!(io, points)
-        zrange = Vector{T}(undef, 2)
-        read!(io, zrange)
-        zvalues = Vector{T}(undef, numpoints)
-        read!(io, zvalues)
-        # mrange = Vector{M}(2)
-        # read!(io, mrange)
-        # measures = Vector{M}(numpoints)
-        # read!(io, measures)
-        MultiPatch{T,M}(box,parts,parttypes,points,zvalues) #,measures)
-    end
+function Base.read(io::IO,::Type{MultiPatch{T,M}}) where {T,M}
+    box = read(io,Rect{Float64})
+    numparts = read(io,Int32)
+    numpoints = read(io,Int32)
+    parts = Vector{Int32}(undef, numparts)
+    read!(io, parts)
+    parttypes = Vector{Int32}(undef, numparts)
+    read!(io, parttypes)
+    points = Vector{Point{T}}(undef, numpoints)
+    read!(io, points)
+    zrange = Vector{T}(undef, 2)
+    read!(io, zrange)
+    zvalues = Vector{T}(undef, numpoints)
+    read!(io, zvalues)
+    # mrange = Vector{M}(2)
+    # read!(io, mrange)
+    # measures = Vector{M}(numpoints)
+    # read!(io, measures)
+    MultiPatch{T,M}(box,parts,parttypes,points,zvalues) #,measures)
+end
 
-    function Base.read(io::IO,::Type{Handle})
-        code = bswap(read(io,Int32))
-        read!(io, Vector{Int32}(undef, 5))
-        fileSize = bswap(read(io,Int32))
-        version = read(io,Int32)
+function Base.read(io::IO,::Type{Handle})
+    code = bswap(read(io,Int32))
+    read!(io, Vector{Int32}(undef, 5))
+    fileSize = bswap(read(io,Int32))
+    version = read(io,Int32)
+    shapeType = read(io,Int32)
+    MBR = read(io,Rect{Float64})
+    zmin = read(io,Float64)
+    zmax = read(io,Float64)
+    mmin = read(io,Float64)
+    mmax = read(io,Float64)
+    jltype = SHAPETYPE[shapeType]
+    shapes = Vector{jltype}(undef, 0)
+    file = Handle(code,fileSize,version,shapeType,MBR,Interval(zmin,zmax),Interval(mmin,mmax),shapes)
+    while(!eof(io))
+        num = bswap(read(io,Int32))
+        rlength = bswap(read(io,Int32))
         shapeType = read(io,Int32)
-        MBR = read(io,Rect{Float64})
-        zmin = read(io,Float64)
-        zmax = read(io,Float64)
-        mmin = read(io,Float64)
-        mmax = read(io,Float64)
-        jltype = SHAPETYPE[shapeType]
-        shapes = Vector{jltype}(undef, 0)
-        file = Handle(code,fileSize,version,shapeType,MBR,Interval(zmin,zmax),Interval(mmin,mmax),shapes)
-        while(!eof(io))
-            num = bswap(read(io,Int32))
-            rlength = bswap(read(io,Int32))
-            shapeType = read(io,Int32)
-            push!(shapes, read(io, jltype))
-        end
-        file
+        push!(shapes, read(io, jltype))
     end
+    file
+end
 
-    function ==(a::Rect, b::Rect)
-        a.left == b.left &&
-            a.bottom == b.bottom &&
-            a.right == b.right &&
-            a.top == b.top
-    end
+function ==(a::Rect, b::Rect)
+    a.left == b.left &&
+        a.bottom == b.bottom &&
+        a.right == b.right &&
+        a.top == b.top
+end
 
-    include("geo_interface.jl")
-    include("shx.jl")
+include("geo_interface.jl")
+include("shx.jl")
+
 end # module

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,6 +1,5 @@
 module Shapefile
 
-import Base.==
 import GeoInterface
 
 mutable struct Rect{T}
@@ -336,7 +335,7 @@ function Base.read(io::IO,::Type{Handle})
     file
 end
 
-function ==(a::Rect, b::Rect)
+function Base.:(==)(a::Rect, b::Rect)
     a.left == b.left &&
         a.bottom == b.bottom &&
         a.right == b.right &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,6 +89,7 @@ for test in test_tuples
     shapes = unique(map(typeof, shp.shapes))
     @test length(shapes) == 1
     @test shapes[1] == test.geomtype
+    @test eltype(shp.shapes) == Union{test.geomtype, Missing}
     # missing and MultiPatch are not covered by the GeoInterface
     if !(test.geomtype <: Union{Missing, Shapefile.MultiPatch})
         @test GeoInterface.coordinates.(shp.shapes) == test.coordinates

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ test_tuples = [
         bbox=Shapefile.Rect{Float64}(0.0, 0.0, 180.0, 170.0),
         ),(
         path="shapelib_testcases/test0.shp",
-        geomtype=Shapefile.NullShape,
+        geomtype=Missing,
         coordinates=nothing,
         bbox=Shapefile.Rect{Float64}(0.0, 0.0, 10.0, 20.0),
     ),(
@@ -89,8 +89,8 @@ for test in test_tuples
     shapes = unique(map(typeof, shp.shapes))
     @test length(shapes) == 1
     @test shapes[1] == test.geomtype
-    # NullShape and MultiPatch are not covered by the GeoInterface
-    if !(test.geomtype <: Union{Shapefile.NullShape, Shapefile.MultiPatch})
+    # missing and MultiPatch are not covered by the GeoInterface
+    if !(test.geomtype <: Union{Missing, Shapefile.MultiPatch})
         @test GeoInterface.coordinates.(shp.shapes) == test.coordinates
     end
     @test shp.MBR == test.bbox
@@ -115,7 +115,9 @@ for test in test_tuples
             num = bswap(read(fd,Int32))
             rlength = bswap(read(fd,Int32))
             shapeType = read(fd,Int32)
-            read(fd, jltype)
+            if shapeType !== Int32(0)
+                read(fd, jltype)
+            end
 
             # records the offest after this geometry record
             push!(offsets, position(fd))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,7 +98,7 @@ end
 
 # Test all .shx files; the values in .shx must match the .shp offsets
 for test in test_tuples
-    
+
     offsets = Int32[]
     contentlens = Int32[]
 
@@ -108,10 +108,10 @@ for test in test_tuples
         shapeType = read(fd,Int32)
         seek(fd,100)
         jltype = Shapefile.SHAPETYPE[shapeType]
-        
+
         push!(offsets, position(fd))
         while(!eof(fd))
-            
+
             num = bswap(read(fd,Int32))
             rlength = bswap(read(fd,Int32))
             shapeType = read(fd,Int32)


### PR DESCRIPTION
Fixes #27, see that issue for discussion.

I opted to go with `missing` rather than `NullShape`, since I see no advantages in using a specific `NullShape`, and `missing` will be nicer if we integrate this package more with Tables/Dataframes etc.

Unfortunately none of the test shapefiles contain a mix of missing and existing geometries, but I tested it with the large file file linked in #27, and that goes well.

Includes some nonfunctional/style changes, but in separate commits.