### PR TITLE
add DBF read support, combining shapes and metadata in Shapefile.Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.DS_Store
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+*.jl.cov
+*.jl.*.cov
+*.jl.mem
+/docs/build/
+/docs/site/
+/test/data/

--- a/Project.toml
+++ b/Project.toml
@@ -2,14 +2,18 @@ name = "Shapefile"
 uuid = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 
 [deps]
+DBFTables = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 GeoInterface = "≥ 0.4.0"
 julia = "≥ 1.0.0"
 
 [extras]
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+RemoteFiles = "cbe49d4c-5af1-5b60-bb70-0a60aa018e1b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["DataFrames", "Test", "RemoteFiles"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,9 @@ GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-GeoInterface = "≥ 0.4.0"
-julia = "≥ 1.0.0"
+DBFTables = "0.2"
+GeoInterface = "0.4"
+julia = "1"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 name = "Shapefile"
 uuid = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
+version = "0.6.0"
 
 [deps]
 DBFTables = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -1,6 +1,6 @@
 module Shapefile
 
-import GeoInterface
+import GeoInterface, DBFTables, Tables
 
 struct Rect
     left::Float64
@@ -131,6 +131,8 @@ mutable struct Handle{T<:Union{<:GeoInterface.AbstractGeometry,Missing}}
     mrange::Interval
     shapes::Vector{T}
 end
+
+Base.length(shp::Handle) = length(shp.shapes)
 
 function Base.read(io::IO, ::Type{Rect})
     minx = read(io, Float64)
@@ -349,6 +351,7 @@ function Base.:(==)(a::Rect, b::Rect)
     a.bottom == b.bottom && a.right == b.right && a.top == b.top
 end
 
+include("table.jl")
 include("geo_interface.jl")
 include("shx.jl")
 

--- a/src/geo_interface.jl
+++ b/src/geo_interface.jl
@@ -95,7 +95,7 @@ function GeoInterface.coordinates(obj::Polygon)
     coords
 end
 
-# copied from GeoInterface.coordinates{T}(obj::Polygon{T}) to match signature here
+# copied from GeoInterface.coordinates(obj::Polygon) to match signature here
 function GeoInterface.coordinates(obj::PolygonM)
     npoints = length(obj.points)
     nparts = length(obj.parts)
@@ -136,7 +136,7 @@ function GeoInterface.coordinates(obj::PolygonM)
     coords
 end
 
-# copied from GeoInterface.coordinates{T}(obj::Polygon{T}) to match signature here
+# copied from GeoInterface.coordinates(obj::Polygon) to match signature here
 function GeoInterface.coordinates(obj::PolygonZ)
     npoints = length(obj.points)
     nparts = length(obj.parts)

--- a/src/table.jl
+++ b/src/table.jl
@@ -72,6 +72,13 @@ Base.propertynames(t::Table) = propertynames(getdbf(t))
 
 Tables.schema(t::Table) = Tables.schema(getdbf(t))
 
+function Base.show(io::IO, t::Table)
+    tt = typeof(t)
+    nr = length(t)
+    nc = length(propertynames(t))
+    println(io, "$tt with $nr rows and $nc columns")
+end
+
 # TODO generalize these with a future GeoInterface/GeoTables
 # should probably be geometry/geometries but don't want to claim these names yet
 "Get the geometry associated with a shapefile row"

--- a/src/table.jl
+++ b/src/table.jl
@@ -1,0 +1,80 @@
+import GeoInterface, DBFTables, Tables
+
+"Shapefile.Table represents both the geometries and associated fields"
+struct Table{T}
+    shp::Handle{T}
+    dbf::DBFTables.Table
+    # ensure matching sizes on construction
+    function Table{T}(shp, dbf) where {T}
+        if length(shp) != length(dbf)
+            throw(ArgumentError("Shapefile and DBF file contain a different amount of rows"))
+        end
+        new{T}(shp, dbf)
+    end
+end
+
+function Table(shp::Handle{T}, dbf::DBFTables.Table) where {T}
+    Table{T}(shp, dbf)
+end
+
+"Read a file into a Shapefile.Table"
+function Table(path::AbstractString)
+    stempath, ext = splitext(path)
+    if lowercase(ext) == ".shp"
+        shp_path = path
+        dbf_path = string(stempath, ".dbf")
+    elseif ext == ""
+        shp_path = string(stempath, ".shp")
+        dbf_path = string(stempath, ".dbf")
+    else
+        throw(ArgumentError("Provide the shapefile with either .shp or no extension"))
+    end
+    isfile(shp_path) || throw(ArgumentError("File not found: $shp_path"))
+    isfile(dbf_path) || throw(ArgumentError("File not found: $dbf_path"))
+
+    shp = open(shp_path) do io
+        read(io, Shapefile.Handle)
+    end
+    dbf = DBFTables.Table(dbf_path)
+    return Shapefile.Table(shp, dbf)
+end
+
+"Struct representing a singe record in a shapefile"
+struct Row{T}
+    geometry::T
+    record::DBFTables.Row
+end
+
+getshp(t::Table) = getfield(t, :shp)
+getdbf(t::Table) = getfield(t, :dbf)
+
+Base.length(t::Table) = length(getshp(t).shapes)
+
+Tables.istable(::Type{<:Table}) = true
+Tables.rows(t::Table) = t
+Tables.columns(t::Table) = t
+Tables.rowaccess(::Type{<:Table}) = true
+Tables.columnaccess(::Type{<:Table}) = true
+
+"Iterate over the rows of a Shapefile.Table, yielding a Shapefile.Row for each row"
+function Base.iterate(t::Table, st = 1)
+    st > length(t) && return nothing
+    geom = @inbounds getshp(t).shapes[st]
+    record = DBFTables.Row(getdbf(t), st)
+    return Row(geom, record), st + 1
+end
+
+Base.getproperty(row::Row, name::Symbol) = getproperty(getfield(row, :record), name)
+Base.getproperty(t::Table, name::Symbol) = getproperty(getdbf(t), name)
+
+Base.propertynames(row::Row) = propertynames(getfield(row, :record))
+Base.propertynames(t::Table) = propertynames(getdbf(t))
+
+Tables.schema(t::Table) = Tables.schema(getdbf(t))
+
+# TODO generalize these with a future GeoInterface/GeoTables
+# should probably be geometry/geometries but don't want to claim these names yet
+"Get the geometry associated with a shapefile row"
+shape(row::Row) = getfield(row, :geometry)
+"Get a vector of the geometries in a shapefile, without any metadata"
+shapes(t::Table) = getshp(t).shapes

--- a/src/table.jl
+++ b/src/table.jl
@@ -77,6 +77,7 @@ function Base.show(io::IO, t::Table)
     nr = length(t)
     nc = length(propertynames(t))
     println(io, "$tt with $nr rows and $nc columns")
+    println(io, Tables.schema(t))
 end
 
 # TODO generalize these with a future GeoInterface/GeoTables

--- a/src/table.jl
+++ b/src/table.jl
@@ -76,8 +76,9 @@ function Base.show(io::IO, t::Table)
     tt = typeof(t)
     nr = length(t)
     nc = length(propertynames(t))
-    println(io, "$tt with $nr rows and $nc columns")
-    println(io, Tables.schema(t))
+    println(io, "$tt with $nr rows and the following $nc columns:\n\t")
+    join(io, propertynames(t), ", ")
+    println(io)
 end
 
 # TODO generalize these with a future GeoInterface/GeoTables

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,4 +139,6 @@ for test in test_tuples
 
 end
 
+include("table.jl")
+
 end  # @testset "Shapefile"

--- a/test/table.jl
+++ b/test/table.jl
@@ -148,10 +148,10 @@ end
         @test Shapefile.shape(r) isa Shapefile.Point
         @test r.featurecla in classes
     end
-    @test sprint(
+    @test startswith(sprint(
             show,
             ne_cities,
-        ) === "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and 38 columns\nTables.Schema:\n :scalerank   Union{Missing, $Int}  \n :natscale    Union{Missing, $Int}  \n :labelrank   Union{Missing, $Int}  \n :featurecla  Union{Missing, String} \n :name        Union{Missing, String} \n :namepar     Union{Missing, String} \n :namealt     Union{Missing, String} \n :diffascii   Union{Missing, $Int}  \n :nameascii   Union{Missing, String} \n :adm0cap     Union{Missing, Float64}\n :capalt      Union{Missing, $Int}  \n :capin       Union{Missing, String} \n :worldcity   Union{Missing, Float64}\n :megacity    Union{Missing, $Int}  \n :sov0name    Union{Missing, String} \n :sov_a3      Union{Missing, String} \n :adm0name    Union{Missing, String} \n :adm0_a3     Union{Missing, String} \n :adm1name    Union{Missing, String} \n :iso_a2      Union{Missing, String} \n :note        Union{Missing, String} \n :latitude    Union{Missing, Float64}\n :longitude   Union{Missing, Float64}\n :changed     Union{Missing, Float64}\n :namediff    Union{Missing, $Int}  \n :diffnote    Union{Missing, String} \n :pop_max     Union{Missing, $Int}  \n :pop_min     Union{Missing, $Int}  \n :pop_other   Union{Missing, $Int}  \n :rank_max    Union{Missing, $Int}  \n :rank_min    Union{Missing, $Int}  \n :geonameid   Union{Missing, Float64}\n :meganame    Union{Missing, String} \n :ls_name     Union{Missing, String} \n :ls_match    Union{Missing, $Int}  \n :checkme     Union{Missing, $Int}  \n :min_zoom    Union{Missing, Float64}\n :ne_id       Union{Missing, $Int}  \n"
+        ), "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and 38 columns\nTables.Schema:\n")
     df_cities = DataFrames.DataFrame(ne_cities)
     @test size(df_cities) == (243, 38)
     @test names(df_cities) == colnames

--- a/test/table.jl
+++ b/test/table.jl
@@ -148,10 +148,10 @@ end
         @test Shapefile.shape(r) isa Shapefile.Point
         @test r.featurecla in classes
     end
-    @test startswith(sprint(
+    @test sprint(
             show,
             ne_cities,
-        ), "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and 38 columns\nTables.Schema:\n")
+        ) === "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and the following 38 columns:\n\t\nscalerank, natscale, labelrank, featurecla, name, namepar, namealt, diffascii, nameascii, adm0cap, capalt, capin, worldcity, megacity, sov0name, sov_a3, adm0name, adm0_a3, adm1name, iso_a2, note, latitude, longitude, changed, namediff, diffnote, pop_max, pop_min, pop_other, rank_max, rank_min, geonameid, meganame, ls_name, ls_match, checkme, min_zoom, ne_id\n"
     df_cities = DataFrames.DataFrame(ne_cities)
     @test size(df_cities) == (243, 38)
     @test names(df_cities) == colnames

--- a/test/table.jl
+++ b/test/table.jl
@@ -78,7 +78,7 @@ end
     @test Tables.columnaccess(ne_land)
     @test Tables.schema(ne_land) == Tables.Schema(
         (:featurecla, :scalerank, :min_zoom),
-        (Union{String,Missing}, Union{Int64,Missing}, Union{Float64,Missing}),
+        (Union{String,Missing}, Union{Int,Missing}, Union{Float64,Missing}),
     )
     for r in ne_land
         @test Shapefile.shape(r) isa Shapefile.Polygon
@@ -107,7 +107,7 @@ end
     @test Tables.columnaccess(ne_coastline)
     @test Tables.schema(ne_coastline) == Tables.Schema(
         (:scalerank, :featurecla, :min_zoom),
-        (Union{Int64,Missing}, Union{String,Missing}, Union{Float64,Missing}),
+        (Union{Int,Missing}, Union{String,Missing}, Union{Float64,Missing}),
     )
     for r in ne_coastline
         @test Shapefile.shape(r) isa Shapefile.Polyline
@@ -151,7 +151,7 @@ end
     @test sprint(
             show,
             ne_cities,
-        ) === "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and 38 columns\n"
+        ) === "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and 38 columns\nTables.Schema:\n :scalerank   Union{Missing, $Int}  \n :natscale    Union{Missing, $Int}  \n :labelrank   Union{Missing, $Int}  \n :featurecla  Union{Missing, String} \n :name        Union{Missing, String} \n :namepar     Union{Missing, String} \n :namealt     Union{Missing, String} \n :diffascii   Union{Missing, $Int}  \n :nameascii   Union{Missing, String} \n :adm0cap     Union{Missing, Float64}\n :capalt      Union{Missing, $Int}  \n :capin       Union{Missing, String} \n :worldcity   Union{Missing, Float64}\n :megacity    Union{Missing, $Int}  \n :sov0name    Union{Missing, String} \n :sov_a3      Union{Missing, String} \n :adm0name    Union{Missing, String} \n :adm0_a3     Union{Missing, String} \n :adm1name    Union{Missing, String} \n :iso_a2      Union{Missing, String} \n :note        Union{Missing, String} \n :latitude    Union{Missing, Float64}\n :longitude   Union{Missing, Float64}\n :changed     Union{Missing, Float64}\n :namediff    Union{Missing, $Int}  \n :diffnote    Union{Missing, String} \n :pop_max     Union{Missing, $Int}  \n :pop_min     Union{Missing, $Int}  \n :pop_other   Union{Missing, $Int}  \n :rank_max    Union{Missing, $Int}  \n :rank_min    Union{Missing, $Int}  \n :geonameid   Union{Missing, Float64}\n :meganame    Union{Missing, String} \n :ls_name     Union{Missing, String} \n :ls_match    Union{Missing, $Int}  \n :checkme     Union{Missing, $Int}  \n :min_zoom    Union{Missing, Float64}\n :ne_id       Union{Missing, $Int}  \n"
     df_cities = DataFrames.DataFrame(ne_cities)
     @test size(df_cities) == (243, 38)
     @test names(df_cities) == colnames

--- a/test/table.jl
+++ b/test/table.jl
@@ -1,0 +1,167 @@
+using Shapefile
+using Test
+using RemoteFiles
+import DBFTables
+import Tables
+import DataFrames
+
+url_physical = "https://github.com/nvkelso/natural-earth-vector/raw/v4.1.0/110m_physical"
+url_cultural = "https://github.com/nvkelso/natural-earth-vector/raw/v4.1.0/110m_cultural"
+datadir = joinpath(@__DIR__, "data")
+
+@RemoteFileSet natural_earth "Natural Earth 110m physical" begin
+    # polygon
+    ne_land_shp = @RemoteFile joinpath(url_physical, "ne_110m_land.shp") dir = datadir
+    ne_land_shx = @RemoteFile joinpath(url_physical, "ne_110m_land.shx") dir = datadir
+    ne_land_dbf = @RemoteFile joinpath(url_physical, "ne_110m_land.dbf") dir = datadir
+    # linestring
+    ne_coastline_shp = @RemoteFile joinpath(url_physical, "ne_110m_coastline.shp") dir = datadir
+    ne_coastline_shx = @RemoteFile joinpath(url_physical, "ne_110m_coastline.shx") dir = datadir
+    ne_coastline_dbf = @RemoteFile joinpath(url_physical, "ne_110m_coastline.dbf") dir = datadir
+    # point
+    ne_cities_shp = @RemoteFile joinpath(
+        url_cultural,
+        "ne_110m_populated_places_simple.shp",
+    ) dir = datadir
+    ne_cities_shx = @RemoteFile joinpath(
+        url_cultural,
+        "ne_110m_populated_places_simple.shx",
+    ) dir = datadir
+    ne_cities_dbf = @RemoteFile joinpath(
+        url_cultural,
+        "ne_110m_populated_places_simple.dbf",
+    ) dir = datadir
+end
+
+download(natural_earth)
+
+@testset "Tables interface" begin
+
+@test isfile(natural_earth)
+
+# create tables that we can use in the tests below
+ne_land = Shapefile.Table(path(natural_earth, "ne_land_shp"))
+ne_coastline = Shapefile.Table(path(natural_earth, "ne_coastline_shp"))
+ne_cities = Shapefile.Table(path(natural_earth, "ne_cities_shp"))
+
+@testset "Create from parts" begin
+    ne_land_shp = open(path(natural_earth, "ne_land_shp")) do io
+        read(io, Shapefile.Handle)
+    end
+    ne_land_dbf = open(path(natural_earth, "ne_land_dbf")) do io
+        DBFTables.Table(io)
+    end
+    ne_land_parts = Shapefile.Table(ne_land_shp, ne_land_dbf)
+
+    @test ne_land_shp isa Shapefile.Handle{Union{Shapefile.Polygon,Missing}}
+    @test ne_land_dbf isa DBFTables.Table
+    @test ne_land_parts isa Shapefile.Table
+end
+
+# without .shp extension it should also work
+@test Shapefile.Table(splitext(path(natural_earth, "ne_land_shp"))[1]) isa Shapefile.Table
+
+@testset "ne_land" begin
+    @test ne_land isa Shapefile.Table{Union{Shapefile.Polygon,Missing}}
+    @test length(ne_land) == 127
+    @test count(true for r in ne_land) == length(ne_land)
+    @test propertynames(ne_land) == [:featurecla, :scalerank, :min_zoom]
+    @test propertynames(first(ne_land)) == [:featurecla, :scalerank, :min_zoom]
+    @test ne_land.featurecla isa Vector{String}
+    @test length(ne_land.scalerank) == length(ne_land)
+    @test sum(ne_land.scalerank) == 58
+    @test Shapefile.shapes(ne_land) isa Vector{Union{Shapefile.Polygon,Missing}}
+    @test Tables.istable(ne_land)
+    @test Tables.rows(ne_land) === ne_land
+    @test Tables.columns(ne_land) === ne_land
+    @test Tables.rowaccess(ne_land)
+    @test Tables.columnaccess(ne_land)
+    @test Tables.schema(ne_land) == Tables.Schema(
+        (:featurecla, :scalerank, :min_zoom),
+        (Union{String,Missing}, Union{Int64,Missing}, Union{Float64,Missing}),
+    )
+    for r in ne_land
+        @test Shapefile.shape(r) isa Shapefile.Polygon
+        @test r.featurecla === "Land"
+    end
+    df_land = DataFrames.DataFrame(ne_land)
+    @test size(df_land) == (127, 3)
+    @test names(df_land) == [:featurecla, :scalerank, :min_zoom]
+    df_land.featurecla isa Vector{String}
+end
+
+@testset "ne_coastline" begin
+    @test ne_coastline isa Shapefile.Table{Union{Shapefile.Polyline,Missing}}
+    @test length(ne_coastline) == 134
+    @test count(true for r in ne_coastline) == length(ne_coastline)
+    @test propertynames(ne_coastline) == [:scalerank, :featurecla, :min_zoom]
+    @test propertynames(first(ne_coastline)) == [:scalerank, :featurecla, :min_zoom]
+    @test ne_coastline.featurecla isa Vector{String}
+    @test length(ne_coastline.scalerank) == length(ne_coastline)
+    @test sum(ne_coastline.scalerank) == 59
+    @test Shapefile.shapes(ne_coastline) isa Vector{Union{Shapefile.Polyline,Missing}}
+    @test Tables.istable(ne_coastline)
+    @test Tables.rows(ne_coastline) === ne_coastline
+    @test Tables.columns(ne_coastline) === ne_coastline
+    @test Tables.rowaccess(ne_coastline)
+    @test Tables.columnaccess(ne_coastline)
+    @test Tables.schema(ne_coastline) == Tables.Schema(
+        (:scalerank, :featurecla, :min_zoom),
+        (Union{Int64,Missing}, Union{String,Missing}, Union{Float64,Missing}),
+    )
+    for r in ne_coastline
+        @test Shapefile.shape(r) isa Shapefile.Polyline
+        @test r.featurecla in ("Coastline", "Country")
+    end
+    df_coastline = DataFrames.DataFrame(ne_coastline)
+    @test size(df_coastline) == (134, 3)
+    @test names(df_coastline) == [:scalerank, :featurecla, :min_zoom]
+    df_coastline.featurecla isa Vector{String}
+end
+
+@testset "ne_cities" begin
+    @test ne_cities isa Shapefile.Table{Union{Shapefile.Point,Missing}}
+    @test length(ne_cities) == 243
+    @test count(true for r in ne_cities) == length(ne_cities)
+    colnames = [
+        :scalerank, :natscale, :labelrank, :featurecla, :name, :namepar, :namealt, :diffascii,
+        :nameascii, :adm0cap, :capalt, :capin, :worldcity, :megacity, :sov0name, :sov_a3,
+        :adm0name, :adm0_a3, :adm1name, :iso_a2, :note, :latitude, :longitude, :changed,
+        :namediff, :diffnote, :pop_max, :pop_min, :pop_other, :rank_max, :rank_min, :geonameid,
+        :meganame, :ls_name, :ls_match, :checkme, :min_zoom, :ne_id,
+    ]
+    @test propertynames(ne_cities) == colnames
+    @test propertynames(first(ne_cities)) == colnames
+    @test ne_cities.featurecla isa Vector{String}
+    @test length(ne_cities.scalerank) == length(ne_cities)
+    @test sum(ne_cities.scalerank) == 612
+    @test Shapefile.shapes(ne_cities) isa Vector{Union{Shapefile.Point,Missing}}
+    @test Tables.istable(ne_cities)
+    @test Tables.rows(ne_cities) === ne_cities
+    @test Tables.columns(ne_cities) === ne_cities
+    @test Tables.rowaccess(ne_cities)
+    @test Tables.columnaccess(ne_cities)
+    classes = ["Admin-0 capital", "Admin-0 capital alt", "Populated place",
+        "Admin-1 capital", "Admin-1 region capital", "Admin-0 region capital"]
+    @test unique(ne_cities.featurecla) == classes
+    for r in ne_cities
+        @test Shapefile.shape(r) isa Shapefile.Point
+        @test r.featurecla in classes
+    end
+    df_cities = DataFrames.DataFrame(ne_cities)
+    @test size(df_cities) == (243, 38)
+    @test names(df_cities) == colnames
+    df_cities.featurecla isa Vector{String}
+end
+
+# no need to use shx in Shapefile.Tables since we read the shapes into a Vector and can thus index them
+# but since we have these files, we may as well try reading them
+ne_shx = [path(rfs) for rfs in files(natural_earth) if endswith(path(rfs), ".shx")]
+@test length(ne_shx) == 3
+for shx_path in ne_shx
+    open(path(natural_earth, "ne_land_shx")) do io
+        read(io, Shapefile.IndexHandle)
+    end
+end
+
+end  # testset "Tables interface"

--- a/test/table.jl
+++ b/test/table.jl
@@ -148,6 +148,10 @@ end
         @test Shapefile.shape(r) isa Shapefile.Point
         @test r.featurecla in classes
     end
+    @test sprint(
+            show,
+            ne_cities,
+        ) === "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and 38 columns\n"
     df_cities = DataFrames.DataFrame(ne_cities)
     @test size(df_cities) == (243, 38)
     @test names(df_cities) == colnames

--- a/test/table.jl
+++ b/test/table.jl
@@ -148,10 +148,14 @@ end
         @test Shapefile.shape(r) isa Shapefile.Point
         @test r.featurecla in classes
     end
+    show_result = "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and the following 38 columns:\n\t\nscalerank, natscale, labelrank, featurecla, name, namepar, namealt, diffascii, nameascii, adm0cap, capalt, capin, worldcity, megacity, sov0name, sov_a3, adm0name, adm0_a3, adm1name, iso_a2, note, latitude, longitude, changed, namediff, diffnote, pop_max, pop_min, pop_other, rank_max, rank_min, geonameid, meganame, ls_name, ls_match, checkme, min_zoom, ne_id\n"
+    if VERSION < v"1.1"
+        show_result = replace(show_result, "Shapefile.Point" => "Point")
+    end
     @test sprint(
             show,
             ne_cities,
-        ) === "Shapefile.Table{Union{Missing, Shapefile.Point}} with 243 rows and the following 38 columns:\n\t\nscalerank, natscale, labelrank, featurecla, name, namepar, namealt, diffascii, nameascii, adm0cap, capalt, capin, worldcity, megacity, sov0name, sov_a3, adm0name, adm0_a3, adm1name, iso_a2, note, latitude, longitude, changed, namediff, diffnote, pop_max, pop_min, pop_other, rank_max, rank_min, geonameid, meganame, ls_name, ls_match, checkme, min_zoom, ne_id\n"
+        ) === show_result
     df_cities = DataFrames.DataFrame(ne_cities)
     @test size(df_cities) == (243, 38)
     @test names(df_cities) == colnames


### PR DESCRIPTION
Shapefile.Table implements the Tables.jl interface.

Going forward it would be nice to use this as a basis to try to develop a kind of GeoTables interface
like mentioned in the README of https://github.com/visr/GeoJSONTables.jl. With GeoJSONTables and Shapefile we will then have two native formats that already implement the Tables interface, that we can use for developing GeoTables.

Depends on https://github.com/JuliaData/DBFTables.jl/pull/9

Closes #19

Note that this does not make use of the shx index files, but since we read all shapes into a vector, there is no need for this, since we can already easily find specific shapes.