### PR TITLE
Add Handle constructor from path

### DIFF
--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -131,9 +131,10 @@ mutable struct Handle{T<:Union{<:GeoInterface.AbstractGeometry,Missing}}
     mrange::Interval
     shapes::Vector{T}
 end
+
 function Handle(path::AbstractString)
     open(path) do io
-        read(io, Shapefile.Handle)
+        read(io, Handle)
     end
 end
 

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -131,6 +131,11 @@ mutable struct Handle{T<:Union{<:GeoInterface.AbstractGeometry,Missing}}
     mrange::Interval
     shapes::Vector{T}
 end
+function Handle(path::AbstractString)
+    open(path) do io
+        read(io, Shapefile.Handle)
+    end
+end
 
 Base.length(shp::Handle) = length(shp.shapes)
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -32,9 +32,7 @@ function Table(path::AbstractString)
     isfile(shp_path) || throw(ArgumentError("File not found: $shp_path"))
     isfile(dbf_path) || throw(ArgumentError("File not found: $dbf_path"))
 
-    shp = open(shp_path) do io
-        read(io, Shapefile.Handle)
-    end
+    shp = Shapefile.Handle(shp_path)
     dbf = DBFTables.Table(dbf_path)
     return Shapefile.Table(shp, dbf)
 end


### PR DESCRIPTION
This just moves the shapefile `read` code from `Table` into it's own constructor, to simplify the syntax when you don't have dbf file