### PR TITLE
add plot recipes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,18 +6,21 @@ version = "0.6.2"
 [deps]
 DBFTables = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DBFTables = "0.2"
 GeoInterface = "0.4, 0.5"
+RecipesBase = "1"
 Tables = "0.2, 1.0"
 julia = "1"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 RemoteFiles = "cbe49d4c-5af1-5b60-bb70-0a60aa018e1b"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataFrames", "Test", "RemoteFiles"]
+test = ["DataFrames", "Plots", "RemoteFiles", "Test"]

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -2,6 +2,8 @@ module Shapefile
 
 import GeoInterface, DBFTables, Tables
 
+using RecipesBase
+
 struct Rect
     left::Float64
     bottom::Float64
@@ -360,5 +362,6 @@ end
 include("table.jl")
 include("geo_interface.jl")
 include("shx.jl")
+include("plotrecipes.jl")
 
 end # module

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,0 +1,7 @@
+@recipe function f(t::Table)
+    getshp(t)
+end
+
+@recipe function f(shp::Handle)
+    shp.shapes
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Shapefile, GeoInterface
+using Shapefile, GeoInterface, Plots
 using Test
 
 test_tuples = [
@@ -95,7 +95,13 @@ for test in test_tuples
         @test GeoInterface.coordinates.(shp.shapes) == test.coordinates
     end
     @test shp.MBR == test.bbox
+
+    # Multipatch can't be plotted, but it's obscure anyway
+    if !(test.geomtype == Shapefile.MultiPatch)
+        plot(shp) # Just test that it actually plots
+    end
 end
+
 
 # Test all .shx files; the values in .shx must match the .shp offsets
 for test in test_tuples

--- a/test/table.jl
+++ b/test/table.jl
@@ -1,6 +1,7 @@
 using Shapefile
 using Test
 using RemoteFiles
+using Plots
 import DBFTables
 import Tables
 import DataFrames
@@ -160,6 +161,12 @@ for shx_path in ne_shx
     open(path(natural_earth, "ne_land_shx")) do io
         read(io, Shapefile.IndexHandle)
     end
+end
+
+@testset "plot tables" begin
+    plot(ne_land)
+    plot(ne_coastline)
+    plot(ne_cities)
 end
 
 end  # testset "Tables interface"


### PR DESCRIPTION
Adds very simple Plots.jl recipes for `Table` and `Handle`, and tests that they work on objects in the test suite.

`Shapefile.MultiPatch` can't be plotted as it's not in GeoInterface.jl - see JuliaGeo/GeoInterface.jl#34