### PR TITLE
use shx for indexing into file if available

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,3 +30,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Shapefile"
 uuid = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 license = "MIT"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 DBFTables = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -359,11 +359,16 @@ function Base.read(io::IO, ::Type{Handle}, index = nothing)
 end
 
 include("shx.jl")
+include("table.jl")
+include("geo_interface.jl")
+include("plotrecipes.jl")
 
 seeknext(io, num, ::Nothing) = nothing
+
 function seeknext(io, num, index::IndexHandle)
-    seek(io, index.indices[num+1].offset*2)
+    seek(io, index.indices[num+1].offset * 2)
 end
+
 function Handle(path::AbstractString, indexpath::AbstractString)
     index = open(indexpath) do io
         read(io, IndexHandle)
@@ -375,12 +380,5 @@ function Base.:(==)(a::Rect, b::Rect)
     a.left == b.left &&
     a.bottom == b.bottom && a.right == b.right && a.top == b.top
 end
-
-include("table.jl")
-
-include("geo_interface.jl")
-include("plotrecipes.jl")
-
-
 
 end # module

--- a/src/table.jl
+++ b/src/table.jl
@@ -22,9 +22,11 @@ function Table(path::AbstractString)
     stempath, ext = splitext(path)
     if lowercase(ext) == ".shp"
         shp_path = path
+        shx_path = string(stempath, ".shx")
         dbf_path = string(stempath, ".dbf")
     elseif ext == ""
         shp_path = string(stempath, ".shp")
+        shx_path = string(stempath, ".shx")
         dbf_path = string(stempath, ".dbf")
     else
         throw(ArgumentError("Provide the shapefile with either .shp or no extension"))
@@ -32,7 +34,11 @@ function Table(path::AbstractString)
     isfile(shp_path) || throw(ArgumentError("File not found: $shp_path"))
     isfile(dbf_path) || throw(ArgumentError("File not found: $dbf_path"))
 
-    shp = Shapefile.Handle(shp_path)
+    shp = if isfile(shx_path)
+        Shapefile.Handle(shp_path,shx_path)
+    else
+        Shapefile.Handle(shp_path)
+    end
     dbf = DBFTables.Table(dbf_path)
     return Shapefile.Table(shp, dbf)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,12 +85,12 @@ test_tuples = [
 for test in test_tuples
     for use_shx in (false, true)
         shp = if use_shx
-            #This accesses shp based on offsets in .shx
+            # this accesses .shp based on offsets in .shx
             stempath, ext = splitext(test.path)
             shxname = string(stempath, ".shx")
             Shapefile.Handle(joinpath(@__DIR__, test.path), joinpath(@__DIR__, shxname))
         else
-            #Use .shp only
+            # use .shp only
             open(joinpath(@__DIR__, test.path)) do fd
                 read(fd, Shapefile.Handle)
             end


### PR DESCRIPTION
Currently, .shx files are ignored when opening a Shapefile and it is assumed that all information is stored in the .shp ion a consecutive way. This led to an error at least in one file in the wild (#51), which would be fixed with this PR. 
