### PR TITLE
RFC: Catch errors when reading single features

### DIFF
--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -343,11 +343,13 @@ function Base.read(io::IO, ::Type{Handle}, index = nothing)
         Interval(mmin, mmax),
         shapes,
     )
-    num = Int32(0)
+    ii = 0
     while (!eof(io))
-        seeknext(io, num, index)
         try
+            ii = ii + 1
+            seeknext(io, ii, index)
             num = bswap(read(io, Int32))
+            @assert num == ii
             rlength = bswap(read(io, Int32))
             shapeType = read(io, Int32)
             if shapeType === Int32(0)
@@ -356,7 +358,7 @@ function Base.read(io::IO, ::Type{Handle}, index = nothing)
                 push!(shapes, read(io, jltype))
             end
         catch e
-            println("An error occured when trying to read corrupt entry $(num+1) in Shapefile: $e")
+            println("An error occured when trying to read corrupt entry $(ii) in Shapefile: $e")
             push!(shapes, missing)
         end
     end
@@ -371,7 +373,7 @@ include("plotrecipes.jl")
 seeknext(io, num, ::Nothing) = nothing
 
 function seeknext(io, num, index::IndexHandle)
-    seek(io, index.indices[num+1].offset * 2)
+    seek(io, index.indices[num].offset * 2)
 end
 
 function Handle(path::AbstractString, indexpath::AbstractString)

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -346,13 +346,18 @@ function Base.read(io::IO, ::Type{Handle}, index = nothing)
     num = Int32(0)
     while (!eof(io))
         seeknext(io, num, index)
-        num = bswap(read(io, Int32))
-        rlength = bswap(read(io, Int32))
-        shapeType = read(io, Int32)
-        if shapeType === Int32(0)
+        try
+            num = bswap(read(io, Int32))
+            rlength = bswap(read(io, Int32))
+            shapeType = read(io, Int32)
+            if shapeType === Int32(0)
+                push!(shapes, missing)
+            else
+                push!(shapes, read(io, jltype))
+            end
+        catch e
+            println("An error occured when trying to read corrupt entry $(num+1) in Shapefile: $e")
             push!(shapes, missing)
-        else
-            push!(shapes, read(io, jltype))
         end
     end
     file


### PR DESCRIPTION
Following up on #52 since we are using shx to move from feature to feature in the file, we can in theory also recover when single entries in the file are broken or the file is truncated. This PR would put the reading of the single entries into a try-catch block moves on if an entry is broken. This is not supposed to be a final implementation, I just wanted to get some feedback on if this is something we want or not. 

Since this is not really compatible with the sequential reading of entries where it is much harder to recover from bad data (though not impossible), it would make sense to split the sequential read algorithm and the shx-based one into different functions, that are called separately in different use cases. I would do this if there is general consensus that we do care about broken files....