### PR TITLE
declare compat with DBFTables v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Shapefile"
 uuid = "8e980c4a-a4fe-5da2-b3a7-4b4b0353a2f4"
 license = "MIT"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 DBFTables = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
@@ -10,16 +10,16 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-DBFTables = "0.2"
+DBFTables = "0.2, 1"
 GeoInterface = "0.4, 0.5"
 RecipesBase = "1"
-Tables = "0.2, 1.0"
+Tables = "0.2, 1"
 julia = "1"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-RemoteFiles = "cbe49d4c-5af1-5b60-bb70-0a60aa018e1b"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+RemoteFiles = "cbe49d4c-5af1-5b60-bb70-0a60aa018e1b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]


### PR DESCRIPTION
There were no breaking changes in v1, hence we can just add the compat entry.

ref https://github.com/JuliaData/DBFTables.jl/pull/17
