### PR TITLE
add shapes method for Handle and refactor

### DIFF
--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -140,9 +140,10 @@ function Handle(path::AbstractString, index=nothing)
     end
 end
 
+shapes(h::Handle) = h.shapes
 
 
-Base.length(shp::Handle) = length(shp.shapes)
+Base.length(shp::Handle) = length(shapes(shp))
 
 function Base.read(io::IO, ::Type{Rect})
     minx = read(io, Float64)

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -3,5 +3,5 @@
 end
 
 @recipe function f(shp::Handle)
-    shp.shapes
+    shapes(shp)
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -52,7 +52,7 @@ end
 getshp(t::Table) = getfield(t, :shp)
 getdbf(t::Table) = getfield(t, :dbf)
 
-Base.length(t::Table) = length(shapes(getshp(t)))
+Base.length(t::Table) = length(shapes(t))
 
 Tables.istable(::Type{<:Table}) = true
 Tables.rows(t::Table) = t

--- a/src/table.jl
+++ b/src/table.jl
@@ -52,7 +52,7 @@ end
 getshp(t::Table) = getfield(t, :shp)
 getdbf(t::Table) = getfield(t, :dbf)
 
-Base.length(t::Table) = length(getshp(t).shapes)
+Base.length(t::Table) = length(shapes(getshp(t)))
 
 Tables.istable(::Type{<:Table}) = true
 Tables.rows(t::Table) = t
@@ -63,7 +63,7 @@ Tables.columnaccess(::Type{<:Table}) = true
 "Iterate over the rows of a Shapefile.Table, yielding a Shapefile.Row for each row"
 function Base.iterate(t::Table, st = 1)
     st > length(t) && return nothing
-    geom = @inbounds getshp(t).shapes[st]
+    geom = @inbounds shapes(t)[st]
     record = DBFTables.Row(getdbf(t), st)
     return Row(geom, record), st + 1
 end
@@ -108,4 +108,4 @@ end
 "Get the geometry associated with a shapefile row"
 shape(row::Row) = getfield(row, :geometry)
 "Get a vector of the geometries in a shapefile, without any metadata"
-shapes(t::Table) = getshp(t).shapes
+shapes(t::Table) = shapes(getshp(t))


### PR DESCRIPTION
This PR adds a `shapes` method for `Handle` for consistency with `Table`, and removes all use of `.shapes`.