### PR TITLE
Load .prj files if they exist

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DBFTables = "0.2, 1"
-GeoFormatTypes = "0.3"
+GeoFormatTypes = "0.4"
 GeoInterface = "0.4, 0.5"
 RecipesBase = "1"
 Tables = "0.2, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.7.4"
 
 [deps]
 DBFTables = "75c7ada1-017a-5fb6-b8c7-2125ff2d6c93"
+GeoFormatTypes = "68eda718-8dee-11e9-39e7-89f7f65f511f"
 GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DBFTables = "0.2, 1"
+GeoFormatTypes = "0.3"
 GeoInterface = "0.4, 0.5"
 RecipesBase = "1"
 Tables = "0.2, 1"

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -492,7 +492,7 @@ function Base.read(io::IO, ::Type{Handle}, index = nothing; path = nothing)
     jltype = SHAPETYPE[shapeType]
     shapes = Vector{Union{jltype,Missing}}(undef, 0)
     crs = nothing
-    if !isnothing(path)
+    if path !== nothing
         prjfile = string(splitext(path)[1], ".prj")
         if isfile(prjfile) 
             try

--- a/src/table.jl
+++ b/src/table.jl
@@ -47,7 +47,7 @@ function Table(path::AbstractString)
     isfile(dbf_path) || throw(ArgumentError("File not found: $dbf_path"))
 
     shp = if isfile(shx_path)
-        Shapefile.Handle(shp_path,shx_path)
+        Shapefile.Handle(shp_path, shx_path)
     else
         Shapefile.Handle(shp_path)
     end
@@ -144,3 +144,5 @@ shape(row::Row) = getfield(row, :geometry)
 Get a vector of the geometries in a shapefile `Table`, without any metadata.
 """
 shapes(t::Table) = shapes(getshp(t))
+
+GeoInterface.crs(t::Table) = GeoInterface.crs(getshp(t))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,8 @@ for test in test_tuples
             end
         end
         shapes = unique(map(typeof, shp.shapes))
+        @test GeoInterface.crs(shp) == nothing
+        @test length(shapes) == 1
         @test length(shapes) == 1
         @test shapes[1] == test.geomtype
         @test eltype(shp.shapes) == Union{test.geomtype,Missing}


### PR DESCRIPTION
Add handling for `.prj` files, so that `GeoInterface.crs(handle_or_table)` returns an `GeoFormatTypes.ESRIWellKnownText` wrapper around the `.prj` text.

Closes #31

@joshday this is kind of trivial, but having a look/review of the PR might be an ok introduction to Shapefile.jl.