### PR TITLE
Generic `write` from GeoInterface compatible geometries

### DIFF
--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -33,6 +33,42 @@ const SHAPETYPE = Dict{Int32,DataType}(
     31 => MultiPatch,
 )
 
+const SHAPECODE = Dict((v => k for (k, v) in SHAPETYPE))
+
+const TRAITSHAPE = Dict{Type,Type}(
+    Nothing => Missing,
+    Missing => Missing,
+    GI.PointTrait => Point,
+    GI.MultiLineStringTrait => Polyline,
+    GI.MultiPolygonTrait => Polygon,
+    GI.MultiPointTrait => MultiPoint,
+)
+const TRAITSHAPE_Z = Dict{Type,Type}(
+    Nothing => Missing,
+    Missing => Missing,
+    GI.PointTrait => PointZ,
+    GI.MultiLineStringTrait => PolylineZ,
+    GI.MultiPolygonTrait => PolygonZ,
+    GI.MultiPointTrait => MultiPointZ,
+)
+
+const TRAITSHAPE_M = Dict{Type,Type}(
+    Nothing => Missing,
+    Missing => Missing,
+    GI.PointTrait => PointM,
+    GI.MultiLineStringTrait => PolylineM,
+    GI.MultiPolygonTrait => PolygonM,
+    GI.MultiPointTrait => MultiPointM,
+)
+
+trait_geom_type(::GI.PolygonTrait) = SubPolygon
+trait_geom_type(::GI.LinearRingTrait) = LinearRing
+trait_geom_type(::GI.PointTrait) = Point
+trait_geom_type(::GI.MultiLineStringTrait) = Polyline
+trait_geom_type(::GI.PolygonTrait) = PolygonTrait
+trait_geom_type(::GI.MultiPointTrait) = MultiPoint
+
+
 include("shx.jl")
 include("handle.jl")
 include("table.jl")

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -35,7 +35,7 @@ const SHAPETYPE = Dict{Int32,DataType}(
 
 const SHAPECODE = Dict((v => k for (k, v) in SHAPETYPE))
 
-const TRAITSHAPE = Dict{Type,Type}(
+const TRAITSHAPE = Dict{DataType,DataType}(
     Nothing => Missing,
     Missing => Missing,
     GI.PointTrait => Point,
@@ -43,7 +43,7 @@ const TRAITSHAPE = Dict{Type,Type}(
     GI.MultiPolygonTrait => Polygon,
     GI.MultiPointTrait => MultiPoint,
 )
-const TRAITSHAPE_Z = Dict{Type,Type}(
+const TRAITSHAPE_Z = Dict{DataType,DataType}(
     Nothing => Missing,
     Missing => Missing,
     GI.PointTrait => PointZ,
@@ -52,7 +52,7 @@ const TRAITSHAPE_Z = Dict{Type,Type}(
     GI.MultiPointTrait => MultiPointZ,
 )
 
-const TRAITSHAPE_M = Dict{Type,Type}(
+const TRAITSHAPE_M = Dict{DataType,DataType}(
     Nothing => Missing,
     Missing => Missing,
     GI.PointTrait => PointM,

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -61,14 +61,6 @@ const TRAITSHAPE_M = Dict{Type,Type}(
     GI.MultiPointTrait => MultiPointM,
 )
 
-trait_geom_type(::GI.PolygonTrait) = SubPolygon
-trait_geom_type(::GI.LinearRingTrait) = LinearRing
-trait_geom_type(::GI.PointTrait) = Point
-trait_geom_type(::GI.MultiLineStringTrait) = Polyline
-trait_geom_type(::GI.PolygonTrait) = PolygonTrait
-trait_geom_type(::GI.MultiPointTrait) = MultiPoint
-
-
 include("shx.jl")
 include("handle.jl")
 include("table.jl")

--- a/src/Shapefile.jl
+++ b/src/Shapefile.jl
@@ -38,5 +38,6 @@ include("handle.jl")
 include("table.jl")
 include("extent.jl")
 include("plotrecipes.jl")
+include("writer.jl")
 
 end # module

--- a/src/common.jl
+++ b/src/common.jl
@@ -88,8 +88,8 @@ struct Header
     mrange::Interval
 end
 function Header(; filesize, shapecode, mbr, zrange, mrange)
-    code = Int32(9994)
-    version = Int32(1000)
+    code = Int32(9994) # Shapefile file code is 9994
+    version = Int32(1000) # Shapefile version is 1000
     return Header(code, filesize, version, shapecode, mbr, zrange, mrange)
 end
 
@@ -109,7 +109,7 @@ function Base.write(io::IO, h::Header)
     bytes = 0
     bytes += Base.write(io, hton(h.code))
     bytes += Base.write(io, zeros(Int32,  5))
-    bytes += Base.write(io, ntoh(h.filesize))
+    bytes += Base.write(io, hton(h.filesize))
     bytes += Base.write(io, h.version)
     bytes += Base.write(io, h.shapecode)
     bytes += Base.write(io, h.MBR)

--- a/src/common.jl
+++ b/src/common.jl
@@ -21,12 +21,28 @@ struct Rect
     top::Float64
 end
 
+union(r1::Rect, r2::Rect) =
+    Rect(min(r1.left, r2.left), 
+         min(r1.bottom, r2.bottom), 
+         max(r1.right, r2.right),
+         max(r1.top, r2.top)
+    )
+
 function Base.read(io::IO, ::Type{Rect})
     minx = read(io, Float64)
     miny = read(io, Float64)
     maxx = read(io, Float64)
     maxy = read(io, Float64)
     Rect(minx, miny, maxx, maxy)
+end
+
+function Base.write(io::IO, rect::Rect)
+    bytes = Int32(0)
+    bytes += Base.write(io, rect.left)
+    bytes += Base.write(io, rect.bottom)
+    bytes += Base.write(io, rect.right)
+    bytes += Base.write(io, rect.top)
+    return bytes
 end
 
 function Base.:(==)(a::Rect, b::Rect)
@@ -44,8 +60,60 @@ struct Interval
     right::Float64
 end
 
+union(i1::Interval, i2::Interval) =
+    Interval(min(i1.left, i2.left), max(i1.right, i2.right))
+
 function Base.read(io::IO, ::Type{Interval})
     left = read(io, Float64)
     right = read(io, Float64)
     Interval(left, right)
+end
+
+function Base.write(io::IO, interval::Interval)
+    Base.write(io, interval.left, interval.right)
+end
+
+"""
+    Header
+
+Common header read/write object for shp and shx files.
+"""
+struct Header
+    code::Int32
+    filesize::Int32
+    version::Int32
+    shapecode::Int32
+    MBR::Rect
+    zrange::Interval
+    mrange::Interval
+end
+function Header(; filesize, shapecode, mbr, zrange, mrange)
+    code = Int32(9994)
+    version = Int32(1000)
+    return Header(code, filesize, version, shapecode, mbr, zrange, mrange)
+end
+
+function Base.read(io::IO, ::Type{Header})
+    code = ntoh(read(io, Int32))
+    read!(io, Vector{Int32}(undef,  5))
+    filesize = ntoh(read(io, Int32))
+    version = read(io, Int32)
+    shapecode = read(io, Int32)
+    mbr = read(io, Rect)
+    zrange = read(io, Interval)
+    mrange = read(io, Interval)
+    return Header(code, filesize, version, shapecode, mbr, zrange, mrange)
+end
+
+function Base.write(io::IO, h::Header)
+    bytes = 0
+    bytes += Base.write(io, hton(h.code))
+    bytes += Base.write(io, zeros(Int32,  5))
+    bytes += Base.write(io, ntoh(h.filesize))
+    bytes += Base.write(io, h.version)
+    bytes += Base.write(io, h.shapecode)
+    bytes += Base.write(io, h.MBR)
+    bytes += Base.write(io, h.zrange)
+    bytes += Base.write(io, h.mrange)
+    return bytes
 end

--- a/src/extent.jl
+++ b/src/extent.jl
@@ -18,7 +18,8 @@ function GI.extent(x::AbstractShape)
     rect = x.MBR
     return Extents.Extent(X=(rect.left, rect.right), Y=(rect.bottom, rect.top))
 end
-function GI.extent(x::Union{ShapeZ,Handle})
+GI.extent(x::Handle) = GI.extent(x.header)
+function GI.extent(x::Union{ShapeZ,Header})
     rect = x.MBR
     return Extents.Extent(X=(rect.left, rect.right), Y=(rect.bottom, rect.top), Z=(x.zrange.left, x.zrange.right))
 end

--- a/src/multipoints.jl
+++ b/src/multipoints.jl
@@ -110,19 +110,3 @@ function Base.read(io::IO, ::Type{MultiPointZ})
     mrange, measures = _readm(io, numpoints)
     MultiPointZ(box, points, zrange, zvalues, mrange, measures)
 end
-
-
-# MultiPoint has no parts
-function _write(io::IO, trait::GI.MultiPointTrait, geom; kw...)
-    bytes = Int64(0)
-    mbr = _calc_mbr(geom)
-    bytes += Base.write(io, mbr)
-    numpoints = Int32(GI.npoint(geom))
-    bytes += Base.write(io, numpoints)
-
-    bytes += _write_xy(io, geom)
-    b, zrange, mrange = _write_others(io, geom; kw...)
-    bytes += b
-
-    return (; bytes, mbr, zrange, mrange)
-end

--- a/src/points.jl
+++ b/src/points.jl
@@ -94,4 +94,3 @@ GI.m(::GI.PointTrait, point::PointZ) = point.m
 GI.z(::GI.PointTrait, point::PointZ) = point.z
 
 _ncoord(::Type{PointZ}) = 3
-_ncoord(::Type{PointZ}) = 3

--- a/src/points.jl
+++ b/src/points.jl
@@ -94,3 +94,4 @@ GI.m(::GI.PointTrait, point::PointZ) = point.m
 GI.z(::GI.PointTrait, point::PointZ) = point.z
 
 _ncoord(::Type{PointZ}) = 3
+_ncoord(::Type{PointZ}) = 3

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -1,5 +1,5 @@
 
-# Shapefiles Polygons are actually MultiPolygons Made up of unsorted rings.
+# Shapefile Polygons are actually MultiPolygons made up of unsorted rings.
 # To handle this we add additional types not in the Shapefile specification.
 # LinearRing represents individual rings while `SubPolygon` is a single external
 # ring and n internal rings (holes).
@@ -44,6 +44,9 @@ Base.push!(p::SubPolygon, x) = Base.push!(parent(p), x)
 
 
 abstract type AbstractPolygon{T} <: AbstractShape end
+
+_hasparts(::GI.MultiPolygonTrait) = true
+_hasparts(::GI.PolygonTrait) = true
 
 _pointtype(::Type{<:AbstractPolygon{T}}) where T = T
 
@@ -157,6 +160,8 @@ function Base.read(io::IO, ::Type{Polygon})
     Polygon(box, parts, points)
 end
 
+Base.:(==)(p1::Polygon, p2::Polygon) = (p1.parts == p2.parts) && (p1.points == p2.points)
+
 """
     PolygonM <: AbstractPolygon
 
@@ -175,6 +180,9 @@ struct PolygonM <: AbstractPolygon{PointM}
     mrange::Interval
     measures::Vector{Float64}
 end
+
+Base.:(==)(p1::PolygonM, p2::PolygonM) =
+    (p1.parts == p2.parts) && (p1.points == p2.points) && (p1.measures == p2.measures)
 
 function Base.read(io::IO, ::Type{PolygonM})
     box = read(io, Rect)
@@ -207,6 +215,9 @@ struct PolygonZ <: AbstractPolygon{PointZ}
     mrange::Interval
     measures::Vector{Float64}
 end
+
+Base.:(==)(p1::PolygonZ, p2::PolygonZ) =
+    (p1.parts == p2.parts) && (p1.points == p2.points) && (p1.zvalues == p2.zvalues) && (p1.measures == p2.measures)
 
 function Base.read(io::IO, ::Type{PolygonZ})
     box = read(io, Rect)

--- a/src/polylines.jl
+++ b/src/polylines.jl
@@ -24,6 +24,8 @@ Base.getindex(lr::LineString{PointZ}, i) = PointZ(lr.xy[i], lr.z[i], lr.m[i])
 
 abstract type AbstractPolyline{T} <: AbstractShape end
 
+_hasparts(::GI.MultiLineStringTrait) = true
+
 _pointtype(::Type{<:AbstractPolyline{T}}) where T = T
 
 Base.convert(::Type{T}, ::GI.MultiLineStringTrait, geom) where T<:AbstractPolyline =
@@ -69,6 +71,9 @@ function Base.read(io::IO, ::Type{Polyline})
     Polyline(box, parts, points)
 end
 
+Base.:(==)(p1::Polyline, p2::Polyline) =
+    (p1.parts == p2.parts) && (p1.points == p2.points)
+
 LineString(geom::Polyline, range) = @views LineString{Point}(geom.points[range])
 
 """
@@ -89,6 +94,9 @@ struct PolylineM <: AbstractPolyline{PointM}
     mrange::Interval
     measures::Vector{Float64}
 end
+
+Base.:(==)(p1::PolylineM, p2::PolylineM) =
+    (p1.parts == p2.parts) && (p1.points == p2.points) && (p1.measures == p2.measures)
 
 LineString(geom::PolylineM, range) =
     @views LineString{PointM}(geom.points[range]; m=geom.measures[range])
@@ -124,6 +132,9 @@ struct PolylineZ <: AbstractPolyline{PointZ}
     mrange::Interval
     measures::Vector{Float64}
 end
+
+Base.:(==)(p1::PolylineZ, p2::PolylineZ) =
+    (p1.parts == p2.parts) && (p1.points == p2.points) && (p1.zvalues == p2.zvalues) && (p1.measures == p2.measures)
 
 LineString(geom::PolylineZ, range) =
     @views LineString{PointZ}(geom.points[range]; z=geom.zvalues[range], m=geom.measures[range])

--- a/src/shx.jl
+++ b/src/shx.jl
@@ -9,36 +9,29 @@
 #
 struct IndexRecord
     offset::Int32
-    contentLen::Int32
+    contentlen::Int32
+end
+
+function Base.write(io, ir::IndexRecord)
+    Base.write(io, hton(ir.offset), hton(ir.contentlen))
 end
 
 struct IndexHandle
-    code::Int32
-    length::Int32
-    version::Int32
-    shapeType::Int32
-    MBR::Rect
-    zrange::Interval
-    mrange::Interval
+    header::Header
     indices::Vector{IndexRecord}
 end
 
-function Base.read(io::IO,::Type{IndexHandle})
-    code = ntoh(read(io,Int32))
-    read!(io, Vector{Int32}(undef, 5))
-    fileSize = ntoh(read(io,Int32))
-    version = read(io,Int32)
-    shapeType = read(io,Int32)
-    MBR = read(io,Rect)
-    zmin = read(io,Float64)
-    zmax = read(io,Float64)
-    mmin = read(io,Float64)
-    mmax = read(io,Float64)
-    jltype = SHAPETYPE[shapeType]
-    records = Vector{IndexRecord}(undef, 0)
-    file = IndexHandle(code,fileSize,version,shapeType,MBR,Interval(zmin,zmax),Interval(mmin,mmax),records)
+function Base.read(io::IO,  ::Type{IndexHandle})
+    header = read(io, Header)
+    records = Vector{IndexRecord}(undef,  0)
     while !eof(io)
-        push!(records, IndexRecord(ntoh(read(io,Int32)),ntoh(read(io,Int32))))
+        push!(records,  IndexRecord(ntoh(read(io, Int32)), ntoh(read(io, Int32))))
     end
-    file
+    return IndexHandle(header, records)
+end
+
+function Base.write(io::IO,  ih::IndexHandle)
+    bytes = Base.write(io, ih.header)
+    bytes += Base.write(io, ih.indices)
+    return bytes
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -61,27 +61,16 @@ function Table(shp::Handle{T}, dbf::DBFTables.Table) where {T}
     Table{T}(shp, dbf)
 end
 function Table(path::AbstractString)
-    stempath, ext = splitext(path)
-    if lowercase(ext) == ".shp"
-        shp_path = path
-        shx_path = string(stempath, ".shx")
-        dbf_path = string(stempath, ".dbf")
-    elseif ext == ""
-        shp_path = string(stempath, ".shp")
-        shx_path = string(stempath, ".shx")
-        dbf_path = string(stempath, ".dbf")
-    else
-        throw(ArgumentError("Provide the shapefile with either .shp or no extension"))
-    end
-    isfile(shp_path) || throw(ArgumentError("File not found: $shp_path"))
-    isfile(dbf_path) || throw(ArgumentError("File not found: $dbf_path"))
+    paths = _shape_paths(path)
+    isfile(paths.shp) || throw(ArgumentError("File not found: $shp_path"))
+    isfile(paths.dbf) || throw(ArgumentError("File not found: $dbf_path"))
 
-    shp = if isfile(shx_path)
-        Shapefile.Handle(shp_path, shx_path)
+    shp = if isfile(paths.shx)
+        Shapefile.Handle(paths.shp, paths.shx)
     else
-        Shapefile.Handle(shp_path)
+        Shapefile.Handle(paths.shp)
     end
-    dbf = DBFTables.Table(dbf_path)
+    dbf = DBFTables.Table(paths.dbf)
     return Shapefile.Table(shp, dbf)
 end
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -62,8 +62,8 @@ function Table(shp::Handle{T}, dbf::DBFTables.Table) where {T}
 end
 function Table(path::AbstractString)
     paths = _shape_paths(path)
-    isfile(paths.shp) || throw(ArgumentError("File not found: $shp_path"))
-    isfile(paths.dbf) || throw(ArgumentError("File not found: $dbf_path"))
+    isfile(paths.shp) || throw(ArgumentError("File not found: $(paths.dbf)"))
+    isfile(paths.dbf) || throw(ArgumentError("File not found: $(paths.dbf)"))
 
     shp = if isfile(paths.shx)
         Shapefile.Handle(paths.shp, paths.shx)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -97,3 +97,21 @@ function _getbounds(points::Vector{Point})
     yrange = extrema(GI.y(p) for p in points)
     return Rect(xrange[1], yrange[1], xrange[2], yrange[2])
 end
+
+
+function _shape_paths(path)
+    stempath, ext = splitext(path)
+    if lowercase(ext) == ".shp"
+        shp = path
+    elseif ext == ""
+        shp = string(stempath, ".shp")
+    else
+        throw(ArgumentError("Provide the shapefile with either `.shp` or no extension"))
+    end
+
+    shx = string(stempath, ".shx")
+    dbf = string(stempath, ".dbf")
+    prj = string(stempath, ".prj")
+
+    return (; shp, shx, dbf, prj)
+end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -250,6 +250,7 @@ end
 # Reverse lookup for Shapetype to Code
 SHAPECODE = Dict(zip(values(Shapefile.SHAPETYPE), keys(Shapefile.SHAPETYPE)))
 
+get_MBR(shapes::Array{Missing}) = Rect(0,0,0,0)
 function get_MBR(shapes::Array{Union{Missing,T}}) where T<:Union{Polyline,Polygon,MultiPoint,PolylineZ,PolygonZ,MultiPointZ,PolylineM,PolygonM,MultiPointM,MultiPatch}
     most_left   = Inf
     most_bottom = Inf
@@ -283,6 +284,7 @@ const GeometriesHasZValues   = Union{PolygonZ,           PolylineZ,            M
 const GeometriesHasNoMValues = Union{Polyline, Polygon, MultiPoint, Point, MultiPatch} # PointZ, PointM are speically handled
 const GeometriesHasMValues   = Union{PolygonZ, PolygonM, PolylineZ, PolylineM, MultiPointZ, MultiPointM}
 
+get_zrange(shapes::Array{Missing}) = Interval(0,0)
 get_zrange(shapes::Array{Union{Missing,T}}) where T<:GeometriesHasNoZValues = Interval(0,0)
 function get_zrange(shapes::Array{Union{Missing,T}}) where T<:GeometriesHasZValues
     # get z range
@@ -306,6 +308,7 @@ function get_zrange(points::Array{Union{Missing,T}}) where T<:PointZ
     return Interval(min_z, max_z)
 end
 
+get_mrange(x::Array{Missing}) = Interval(0,0)
 get_mrange(x::Array{Union{Missing,T}}) where T<:GeometriesHasNoMValues = Interval(0.0,0.0)
 function get_mrange(shapes::Array{Union{Missing,T}}) where T<:GeometriesHasMValues
     # get m range

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1,0 +1,417 @@
+function Base.write(io::IO, rect::Rect)
+    bytes = Int32(0)
+    bytes += write(io, rect.left)
+    bytes += write(io, rect.bottom)
+    bytes += write(io, rect.right)
+    bytes += write(io, rect.top)
+    return bytes
+end
+
+function Base.write(io::IO, point::Point)
+    bytes = Int32(0)
+    bytes += write(io, point.x)
+    bytes += write(io, point.y)
+
+    return bytes
+end
+
+function Base.write(io::IO, point_m::PointM)
+    bytes = Int32(0)
+
+    bytes += write(io, point_m.x )
+    bytes += write(io, point_m.y )
+    bytes += write(io, point_m.m ) # measure
+
+    return bytes
+end
+
+function Base.write(io::IO, point_z::PointZ)
+
+    bytes = Int32(0)
+
+    bytes +=  write(io, point_z.x)
+    bytes +=  write(io, point_z.y)
+    bytes +=  write(io, point_z.z)
+    bytes +=  write(io, point_z.m)
+
+    return bytes
+end
+
+# Write an array of Point, PointZ, PointM
+function Base.write(io::IO, geo::Array{T}) where T<: Union{Point, PointM, PointZ} 
+    bytes = write.(Ref(io), geo)
+    return sum(bytes)
+end
+
+
+function Base.write(io::IO, polyline::Polyline)
+    bytes = Int32(0)
+
+    mbr_box = polyline.MBR
+    numparts  = Int32(length(polyline.parts))
+    numpoints = Int32(length(polyline.points))
+    
+    bytes += write(io, mbr_box)
+    bytes += write(io, numparts)
+    bytes += write(io, numpoints)
+    
+    # Write an array of el_type
+    bytes += write(io, polyline.parts)
+    bytes += write(io, polyline.points)
+
+    return bytes
+end
+
+function Base.write(io::IO, polyline_m::PolylineM)
+    bytes = Int32(0)
+
+    mbr_box = polyline_m.MBR
+    numparts = Int32(length(polyline_m.parts ))
+    numpoints = Int32(length(polyline_m.parts ))
+    
+    bytes += write(io, polyline_m.parts)
+    bytes += write(io, polyline_m.points)
+    
+    mrange = extrema(polyline_m.measures)
+    bytes += write(io, mrange...)
+    bytes += write(io, polyline_m.measures)
+
+    return bytes
+end
+
+function Base.write(io::IO, polyline_z::PolylineZ)
+    bytes = Int32(0)
+
+    mbr_box = polyline_z.MBR
+    numparts  = Int32(length(polyline_z.parts ))
+    numpoints = Int32(length(polyline_z.numpoints ))
+    
+    bytes += write(io, mbr_box)
+    bytes += write(io, numparts)
+    bytes += write(io, numpoints)
+
+    bytes += write(io, polyline_z.parts)
+    bytes += write(io, polyline_z.points)
+    
+    zrange = extrema(polyline_z.zvalues)
+    bytes += write(io, zrange...)
+    bytes += write(io, polyline_z.zvalues)
+    
+    mrange = extrema(polyline_z.measures)
+    bytes += write(io, mrange...)
+    bytes += write(io, polyline_z.measures)
+
+    return bytes
+end
+
+function Base.write(io::IO, polygon::Polygon)
+    bytes = Int32(0)
+
+    mbr_box = polygon.MBR
+    numparts = Int32(length(polygon.parts))
+    numpoints = Int32(length(polygon.points))
+
+    bytes += write(io, mbr_box)
+    bytes += write(io, numparts)
+    bytes += write(io, numpoints)
+    
+    bytes += write(io, polygon.parts)
+    bytes += write(io, polygon.points)
+    
+    return bytes
+end
+
+function Base.write(io::IO, polygon_m::PolygonM)
+    bytes = Int32(0)
+    
+    mbr_box = polygon_m.MBR
+    numparts = Int32(length(polygon_m.parts))
+    numpoints = Int32(length(polygon_m.points))
+    
+    bytes += write(io, mbr_box)
+    bytes += write(io, numparts)
+    bytes += write(io, numpoints)
+
+    bytes += write(io, polygon_m.parts)
+    bytes += write(io, polygon_m.points)
+
+    mrange = extrema(polygon_m.measures)
+    bytes += write(io, mrange...)
+    bytes += write(io, polygon_m.measures)
+    
+    return bytes
+end
+
+function Base.write(io::IO, polygon_z::PolygonZ)
+    bytes = Int32(0)
+
+    mbr_box = polygon_z.MBR
+    numparts = Int32(length(polygon_z.parts))
+    numpoints = Int32(length(polygon_z.points))
+    
+    bytes += write(io, mbr_box)
+    bytes += write(io, numparts)
+    bytes += write(io, numpoints)
+
+    bytes += write(io, polygon_z.parts)
+    bytes += write(io, polygon_z.points)
+
+    zrange = extrema(polygon_z.zvalues)
+    bytes += write(io, zrange...)
+    bytes += write(io, polygon_z.zvalues)
+
+    mrange = extrema(polygon_z.measures)
+    bytes += write(io, mrange...)
+    bytes += write(io, polygon_z.measures)
+
+    return bytes
+end
+
+function Base.write(io::IO, multipoint::MultiPoint)
+    bytes = Int32(0)
+
+    mbr_box  = multipoint.MBR
+    numpoints = Int32(length(multipoint.points))
+
+    bytes += write(io, mbr_box)
+    bytes += write(io, numpoints)
+    bytes += write(io, multipoint.points)
+    
+    return bytes
+end
+
+function Base.write(io::IO, multipoint_m::MultiPointM)
+    bytes = Int32(0)
+
+    mbr_box = multipoint_m.MBR
+    numpoints = Int32(length(multipoint_m.points))
+    bytes += write(io, mbr_box)
+    bytes += write(io, numpoints)
+    bytes += write(io, multipoint_m.points)
+
+    mrange = extrema(multipoint_m.measures)
+    bytes += write(io, mrange...)
+    bytes += write(io, multipoint_m.measures)
+
+    return bytes
+end
+
+function Base.write(io::IO, multipoint_z::MultiPointZ)
+    bytes = Int32(0)
+
+    mbr_box = multipoint_z.MBR
+    numpoints = Int32(length(multipoint_z.points))
+
+    bytes += write(io, mbr_box)
+    bytes += write(io, numpoints)
+    bytes += write(io, multipoint_z.points)
+    
+    zrange = extrema(multipoint_z.zvalues)
+    bytes += write(io, zrange...)
+    bytes += write(io, multipoint_z.zvalues)
+
+    mrange = extrema(multipoint_z.measures)
+    bytes += write(io, mrange...)
+    bytes += write(io, multipoint_z.measures)
+
+    return bytes
+end
+
+function Base.write(io::IO, multipatch::MultiPatch)
+    bytes = Int32(0)
+    
+    mbr_box = multipatch.MBR
+    numparts = Int32(length(multipatch.parts))
+    numpoints = Int32(length(multipatch.points))
+
+    bytes += write(io, mbr_box)
+    bytes += write(io, numparts)
+    bytes += write(io, numpoints)
+
+    bytes += write(io, multipatch.parts)
+    bytes += write(io, multipatch.parttypes)
+    
+    bytes += write(io, multipatch.points)
+    
+    zrange = extrema(multipatch.zvalues)
+    bytes += write(io, zrange...)
+    bytes += write(io, multipatch.zvalues)
+    return bytes
+end
+
+# Reverse lookup for Shapetype to Code
+SHAPECODE = Dict(zip(values(Shapefile.SHAPETYPE), keys(Shapefile.SHAPETYPE)))
+
+function get_MBR(shapes::Array{Union{Missing,T}}) where T<:Union{Polyline,Polygon,MultiPoint,PolylineZ,PolygonZ,MultiPointZ,PolylineM,PolygonM,MultiPointM,MultiPatch}
+    most_left   = Inf
+    most_bottom = Inf
+    most_right  = -Inf
+    most_top    = -Inf
+    for shape in skipmissing(shapes)
+        most_left   = min(shape.MBR.left,   most_left)
+        most_bottom = min(shape.MBR.bottom, most_bottom)
+        most_right  = max(shape.MBR.right,  most_right)
+        most_top    = max(shape.MBR.top,    most_top)
+    end
+    return Rect(most_left, most_bottom, most_right, most_top)
+end
+
+function get_MBR(points::Array{T}) where T<:Union{Point,PointM,PointZ}
+    most_left   = Inf
+    most_bottom = Inf
+    most_right  = -Inf
+    most_top    = -Inf
+    for point in points
+        most_left   = min(point.x, most_left)
+        most_bottom = min(point.y, most_bottom)
+        most_right  = max(point.x, most_right)
+        most_top    = max(point.y, most_top)
+    end
+    return Rect(most_left, most_bottom, most_right, most_top)
+end
+
+function Base.write(io::IO, shapes::Array{Union{Missing,T}}) where T<:Union{Point,Polyline,Polygon,MultiPoint,PointZ,PolylineZ,PolygonZ,MultiPointZ,PointM,PolylineM,PolygonM,MultiPointM,MultiPatch}
+    
+    # Define some temorary io buffer to store raw bytes
+    geometries_io = IOBuffer()
+    record_io     = IOBuffer()
+
+    # Write all the shapes into a main block of data (geometries_io)
+    content_size = 0
+    num          = 0
+    rec_length   = 0
+
+    shapeType = SHAPECODE[T]
+    for shape in shapes
+        
+        # Write Record to temorary buffer first
+        bytes = 0
+        if !ismissing(shape)
+            bytes += write( record_io, shapeType)
+            bytes += write( record_io, shape)
+        else
+            # Null Shape
+            bytes += write( record_io, SHAPECODE[Missing])
+        end
+
+        # Record Header
+        # 32-bits (4 bytes) Record Number + 32-bits (4 bytes) Content length = 8 bytes
+        rec_length = bytes + 8 
+        write( geometries_io, bswap(Int32(num)))
+        
+        # Record length measured in 16-bit words (1-unit is 2-bytes (16-bits))
+        # So we divide record length recorded in bytes (8-bits) by 2 into 1 unit (16-bit/2 bytes) 
+        write( geometries_io, bswap(Int32(rec_length /2)))
+        write( geometries_io, take!(record_io))
+        
+        content_size += rec_length
+
+        # !TODO: Here is where we extract and store the shx file content offset number        
+
+        # Zero-based record number; Increment from 0, and increment after record.
+        num += 1
+         
+    end
+
+    # 
+    # Generate Basic File header information
+    #
+    code        = 9994
+    file_length = content_size + 100 
+    version     = 1000
+    
+    #
+    # Compute Shape-dependent information
+    #   1. MBR; Minimul Bounding Region, a up-right rectangular lat,lon box encapsulating all data point. 
+    #   2. zrange; An 1-dimensional interval encapsulating all z-values presented in the data 
+    #   3. mrange; An 1-dimensional interval encapsulating all measurements values presented in the data
+    #
+    # MBR       = Rect(0,0,0,0)
+    MBR = get_MBR(shapes)
+    
+    zrange    = Interval(0,0)
+    mrange    = Interval(0,0)
+    if T in (PolygonZ, PolylineZ, MultiPointZ, MultiPatch)
+        # get z range
+        min_z = +Inf
+        max_z = -Inf
+        for shape in shapes
+            for zvalue in shape.zvalues
+                min_z = min(min_z, zvalue)
+                max_z = max(max_z, zvalue)
+            end 
+        end
+        zrange = Interval(min_z, max_z)
+    
+    elseif T in (PointZ,)
+        min_z = +Inf
+        max_z = -Inf
+        for point in shapes
+            min_z = min(min_z, point.z)
+            max_z = max(max_z, point.z)
+        end
+        zrange = Interval(min_z, max_z)
+    end
+
+    if T in (PolygonZ, PolygonM, PolylineZ, PolylineM, MultiPointZ, MultiPointM)
+        # get m range
+        min_m = +Inf
+        max_m = -Inf
+        for shape in shapes
+            for measure in shape.measures
+                min_m = min(min_m, measure)
+                max_m = max(max_m, measure)
+            end 
+        end
+        mrange = Interval(min_m, max_m)
+    
+    elseif T in (PointM, PointZ)
+        min_m = +Inf
+        max_m = -Inf
+        for shape in shapes
+            for measure in shape.measures
+                min_m = min(min_m, measure)
+                max_m = max(max_m, measure)
+            end 
+        end
+        mrange = Interval(min_m, max_m)
+    end
+
+    #
+    # Write File Header Information into file
+    #
+    bytes = 0
+    bytes += write(io, bswap(Int32(code)))
+    # code = bswap(read(io, Int32))
+
+    bytes += write(io, Int32[0,0,0,0,0])
+    # read!(io, Vector{Int32}(undef, 5))
+    
+    # !NOTE: Record in 16-bits words
+    bytes += write(io, bswap(Int32(file_length/2)))
+    # content_size = bswap(read(io, Int32))
+    
+    bytes += write(io, Int32(version))
+    # version = read(io, Int32)
+
+    bytes += write(io, Int32(shapeType))
+    # shapeType = read(io, Int32)
+    
+    bytes += write(io, MBR)
+    # MBR = read(io, Rect)
+    
+    bytes += write(io, zrange.left)
+    bytes += write(io, zrange.right)
+    # zmin = read(io, Float64)
+    # zmax = read(io, Float64)
+    
+    bytes += write(io, mrange.left)
+    bytes += write(io, mrange.right)
+    # mmin = read(io, Float64)
+    # mmax = read(io, Float64)
+    @show bytes
+
+    # Write the maind block of data into the rest of the shape file
+    write(io, take!(geometries_io))
+    
+end

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -1,447 +1,295 @@
-function Base.write(io::IO, rect::Rect)
-    bytes = Int32(0)
-    bytes += write(io, rect.left)
-    bytes += write(io, rect.bottom)
-    bytes += write(io, rect.right)
-    bytes += write(io, rect.top)
-    return bytes
-end
-
-function Base.write(io::IO, point::Point)
-    bytes = Int32(0)
-    bytes += write(io, point.x)
-    bytes += write(io, point.y)
-
-    return bytes
-end
-
-function Base.write(io::IO, point_m::PointM)
-    bytes = Int32(0)
-
-    bytes += write(io, point_m.x )
-    bytes += write(io, point_m.y )
-    bytes += write(io, point_m.m ) # measure
-
-    return bytes
-end
-
-function Base.write(io::IO, point_z::PointZ)
-
-    bytes = Int32(0)
-
-    bytes +=  write(io, point_z.x)
-    bytes +=  write(io, point_z.y)
-    bytes +=  write(io, point_z.z)
-    bytes +=  write(io, point_z.m)
-
-    return bytes
-end
-
-# Write an array of Point, PointZ, PointM
-function Base.write(io::IO, geo::Array{T}) where T<: Union{Point, PointM, PointZ} 
-    bytes = write.(Ref(io), geo)
-    return sum(bytes)
-end
-
-
-function Base.write(io::IO, polyline::Polyline)
-    bytes = Int32(0)
-
-    mbr_box = polyline.MBR
-    numparts  = Int32(length(polyline.parts))
-    numpoints = Int32(length(polyline.points))
-    
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-    
-    # Write an array of el_type
-    bytes += write(io, polyline.parts)
-    bytes += write(io, polyline.points)
-
-    return bytes
-end
-
-function Base.write(io::IO, polyline_m::PolylineM)
-    bytes = Int32(0)
-
-    mbr_box = polyline_m.MBR
-    numparts  = Int32(length(polyline_m.parts ))
-    numpoints = Int32(length(polyline_m.points ))
-    
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-    
-    bytes += write(io, polyline_m.parts)
-    bytes += write(io, polyline_m.points)
-    
-    mrange = extrema(polyline_m.measures)
-    bytes += write(io, mrange...)
-    bytes += write(io, polyline_m.measures)
-
-    return bytes
-end
-
-function Base.write(io::IO, polyline_z::PolylineZ)
-    bytes = Int32(0)
-
-    mbr_box = polyline_z.MBR
-    numparts  = Int32(length(polyline_z.parts ))
-    numpoints = Int32(length(polyline_z.points ))
-    
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-
-    bytes += write(io, polyline_z.parts)
-    bytes += write(io, polyline_z.points)
-    
-    zrange = extrema(polyline_z.zvalues)
-    bytes += write(io, zrange...)
-    bytes += write(io, polyline_z.zvalues)
-    
-    mrange = extrema(polyline_z.measures)
-    bytes += write(io, mrange...)
-    bytes += write(io, polyline_z.measures)
-
-    return bytes
-end
-
-function Base.write(io::IO, polygon::Polygon)
-    bytes = Int32(0)
-
-    mbr_box = polygon.MBR
-    numparts = Int32(length(polygon.parts))
-    numpoints = Int32(length(polygon.points))
-
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-    
-    bytes += write(io, polygon.parts)
-    bytes += write(io, polygon.points)
-    
-    return bytes
-end
-
-function Base.write(io::IO, polygon_m::PolygonM)
-    bytes = Int32(0)
-    
-    mbr_box = polygon_m.MBR
-    numparts = Int32(length(polygon_m.parts))
-    numpoints = Int32(length(polygon_m.points))
-    
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-
-    bytes += write(io, polygon_m.parts)
-    bytes += write(io, polygon_m.points)
-
-    mrange = extrema(polygon_m.measures)
-    bytes += write(io, mrange...)
-    bytes += write(io, polygon_m.measures)
-    
-    return bytes
-end
-
-function Base.write(io::IO, polygon_z::PolygonZ)
-    bytes = Int32(0)
-
-    mbr_box = polygon_z.MBR
-    numparts = Int32(length(polygon_z.parts))
-    numpoints = Int32(length(polygon_z.points))
-    
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-
-    bytes += write(io, polygon_z.parts)
-    bytes += write(io, polygon_z.points)
-
-    zrange = extrema(polygon_z.zvalues)
-    bytes += write(io, zrange...)
-    bytes += write(io, polygon_z.zvalues)
-
-    mrange = extrema(polygon_z.measures)
-    bytes += write(io, mrange...)
-    bytes += write(io, polygon_z.measures)
-
-    return bytes
-end
-
-function Base.write(io::IO, multipoint::MultiPoint)
-    bytes = Int32(0)
-
-    mbr_box  = multipoint.MBR
-    numpoints = Int32(length(multipoint.points))
-
-    bytes += write(io, mbr_box)
-    bytes += write(io, numpoints)
-    bytes += write(io, multipoint.points)
-    
-    return bytes
-end
-
-function Base.write(io::IO, multipoint_m::MultiPointM)
-    bytes = Int32(0)
-
-    mbr_box = multipoint_m.MBR
-    numpoints = Int32(length(multipoint_m.points))
-    bytes += write(io, mbr_box)
-    bytes += write(io, numpoints)
-    bytes += write(io, multipoint_m.points)
-
-    mrange = extrema(multipoint_m.measures)
-    bytes += write(io, mrange...)
-    bytes += write(io, multipoint_m.measures)
-
-    return bytes
-end
-
-function Base.write(io::IO, multipoint_z::MultiPointZ)
-    bytes = Int32(0)
-
-    mbr_box = multipoint_z.MBR
-    numpoints = Int32(length(multipoint_z.points))
-
-    bytes += write(io, mbr_box)
-    bytes += write(io, numpoints)
-    bytes += write(io, multipoint_z.points)
-    
-    zrange = extrema(multipoint_z.zvalues)
-    bytes += write(io, zrange...)
-    bytes += write(io, multipoint_z.zvalues)
-
-    mrange = extrema(multipoint_z.measures)
-    bytes += write(io, mrange...)
-    bytes += write(io, multipoint_z.measures)
-
-    return bytes
-end
-
-function Base.write(io::IO, multipatch::MultiPatch)
-    bytes = Int32(0)
-    
-    mbr_box = multipatch.MBR
-    numparts = Int32(length(multipatch.parts))
-    numpoints = Int32(length(multipatch.points))
-
-    bytes += write(io, mbr_box)
-    bytes += write(io, numparts)
-    bytes += write(io, numpoints)
-
-    bytes += write(io, multipatch.parts)
-    bytes += write(io, multipatch.parttypes)
-    
-    bytes += write(io, multipatch.points)
-    
-    zrange = extrema(multipatch.zvalues)
-    bytes += write(io, zrange...)
-    bytes += write(io, multipatch.zvalues)
-    
-    # mrange = extrema(multipatch.mvalues)
-    # bytes += write(io, mrange...)
-    # bytes += write(io, multipatch.measures)
-    return bytes
-end
-
 # Reverse lookup for Shapetype to Code
-SHAPECODE = Dict(zip(values(Shapefile.SHAPETYPE), keys(Shapefile.SHAPETYPE)))
-
-get_MBR(shapes::Array{Missing}) = Rect(0,0,0,0)
-function get_MBR(shapes::Array{Union{Missing,T}}) where T<:Union{Polyline,Polygon,MultiPoint,PolylineZ,PolygonZ,MultiPointZ,PolylineM,PolygonM,MultiPointM,MultiPatch}
-    most_left   = Inf
-    most_bottom = Inf
-    most_right  = -Inf
-    most_top    = -Inf
-    for shape in skipmissing(shapes)
-        most_left   = min(shape.MBR.left,   most_left)
-        most_bottom = min(shape.MBR.bottom, most_bottom)
-        most_right  = max(shape.MBR.right,  most_right)
-        most_top    = max(shape.MBR.top,    most_top)
+write(path::AbstractString, h::Handle) = write(path, h.shapes)
+function write(path::AbstractString, obj; force=false)
+    paths = _shape_paths(path)
+    if isfile(paths.shp)
+        if force
+            rm(paths.shp)
+        else
+            throw(ArgumentError("File already exists at `$(paths.shp)`. Use `force=true` to write anyway."))
+        end
     end
-    return Rect(most_left, most_bottom, most_right, most_top)
-end
-
-function get_MBR(points::Array{Union{Missing,T}}) where T<:Union{Point,PointM,PointZ}
-    most_left   = Inf
-    most_bottom = Inf
-    most_right  = -Inf
-    most_top    = -Inf
-    for point in skipmissing(points)
-        most_left   = min(point.x, most_left)
-        most_bottom = min(point.y, most_bottom)
-        most_right  = max(point.x, most_right)
-        most_top    = max(point.y, most_top)
+    if Tables.istable(obj)
+        geomcol = GI.geometrycolumn(obj)
+        geoms = Tables.getcolumn(obj, geomcol)
+        # DBFTables.Table(obj) # TODO remove geom column
+        # DBFTables.write # TODO DBF write function
+    else
+        geoms = obj
     end
-    return Rect(most_left, most_bottom, most_right, most_top)
-end
 
-const GeometriesHasNoZValues = Union{          PolygonM,            PolylineM,              MultiPointM,           Polyline, Polygon, MultiPoint, Point, PointM} # PointZ is speically handled 
-const GeometriesHasZValues   = Union{PolygonZ,           PolylineZ,            MultiPointZ,             MultiPatch} 
-const GeometriesHasNoMValues = Union{Polyline, Polygon, MultiPoint, Point, MultiPatch} # PointZ, PointM are speically handled
-const GeometriesHasMValues   = Union{PolygonZ, PolygonM, PolylineZ, PolylineM, MultiPointZ, MultiPointM}
+    # Write .shp file
+    io = open(paths.shp, "a+")
 
-get_zrange(shapes::Array{Missing}) = Interval(0,0)
-get_zrange(shapes::Array{Union{Missing,T}}) where T<:GeometriesHasNoZValues = Interval(0,0)
-function get_zrange(shapes::Array{Union{Missing,T}}) where T<:GeometriesHasZValues
-    # get z range
-    min_z = +Inf
-    max_z = -Inf
-    for shape in skipmissing(shapes)
-        for zvalue in shape.zvalues
-            min_z = min(min_z, zvalue)
-            max_z = max(max_z, zvalue)
-        end 
-    end
-    return Interval(min_z, max_z)    
-end
-function get_zrange(points::Array{Union{Missing,T}}) where T<:PointZ
-    min_z = +Inf
-    max_z = -Inf
-    for point in skipmissing(points)
-        min_z = min(min_z, point.z)
-        max_z = max(max_z, point.z)
-    end
-    return Interval(min_z, max_z)
-end
+    shx_indices = IndexRecord[]
+    bytes = 0
+    content_size = 0
+    first_geom = true
+    local mbr, zrange, mrange
 
-get_mrange(x::Array{Missing}) = Interval(0,0)
-get_mrange(x::Array{Union{Missing,T}}) where T<:GeometriesHasNoMValues = Interval(0.0,0.0)
-function get_mrange(shapes::Array{Union{Missing,T}}) where T<:GeometriesHasMValues
-    # get m range
-    min_m = +Inf
-    max_m = -Inf
-    for shape in skipmissing(shapes)
-        for measure in shape.measures
-            min_m = min(min_m, measure)
-            max_m = max(max_m, measure)
-        end 
-    end
-    return Interval(min_m, max_m)
-end
-function get_mrange(points::Array{Union{Missing,T}}) where T<:Union{PointM, PointZ}
-    min_m = +Inf
-    max_m = -Inf
-    for point in skipmissing(points)
-        min_m = min(min_m, point.m)
-        max_m = max(max_m, point.m)
-    end
-    return Interval(min_m, max_m)
-end
+    # Write an emtpy header 
+    # We go back later and write it properly later, so we don't have to precalculate everything.
+    dummy_header = Header(;
+        filesize=0, 
+        shapecode=SHAPECODE[Missing],
+        mbr=Rect(0.0, 0.0, 0.0, 0.0),
+        zrange=Interval(0.0, 0.0),
+        mrange=Interval(0.0, 0.0),
+    )
+    bytes += Base.write(io, dummy_header)
+    header_bytes = bytes
 
-const AllShapeTypes = Union{Point,Polyline,Polygon,MultiPoint,PointZ,PolylineZ,PolygonZ,MultiPointZ,PointM,PolylineM,PolygonM,MultiPointM,MultiPatch}
-function Base.write(io::IO, ::Type{Handle}, shapes::Array{Union{Missing,T}}) where T<:AllShapeTypes
-    
     # Since all the headers has some sort of content length information before the data block.
     # The code here will write out the data into a IOBuffer first to get the content length.
     # Finally it write the length information and then unload the IOBuffer data into the main block.
-
-    # Define some temorary io buffer to store raw bytes
-    geometries_io = IOBuffer()
-    record_io     = IOBuffer()
-
-    # Write all the shapes into a main block of data (geometries_io)
-    content_size = 0
-    num          = 0
-    rec_length   = 0
-
     
-    # NOTE:
-    # Since if we are allowing shapes to be an array of Union{Missing,AllShapeType}
-    # We have to default the base shapefile is Null shape
-    # Until there is AT LEAST ONE non-null shape type
-    # Then we will set the whole shapefile as such non-null shape type
-    shapeType = SHAPECODE[Missing]
-    for shape in shapes
-        # One -based record number; Increment from 0, and increment after record.
-        num += 1
-        
-        # Write Record to temorary buffer first
-        bytes = 0
-        if !ismissing(shape)
-            shapeType = SHAPECODE[typeof(shape)]
-            bytes += write( record_io, shapeType)
-            bytes += write( record_io, shape)
-        else
-            # Null Shape
-            bytes += write( record_io, SHAPECODE[Missing])
+    # Detect the shape type code from the first available geometry
+    # There can only be one shape type in the file.
+    if iterate(skipmissing(geoms)) == nothing
+        trait = Missing
+        hasz = hasm = false
+        shapecode = 0 
+        mbr = Rect(0.0, 0.0, 0.0, 0.0)
+        zrange = Interval(0.0, 0.0)
+        mrange = Interval(0.0, 0.0)
+    else
+        geom1 = first(skipmissing(geoms))
+        GI.isgeometry(geom1) || error("$(typeof(geom1)) is not a geometry")
+        trait = GI.geomtrait(geom1)
+        if trait isa GI.GeometryCollectionTrait 
+            @warn "Geometry Collections or MultiPatch cannot be written using Shapefile.jl"
+            return nothing
         end
-        
-        @assert bytes == record_io.size "The hardcoded accumulation of bytes should match how much bytes it has written into the buffer!"
+        hasz = GI.is3d(geom1)
+        hasm = GI.ismeasured(geom1)
+        shapecode = if hasz
+            SHAPECODE[TRAITSHAPE_Z[typeof(trait)]]
+        elseif hasm
+            SHAPECODE[TRAITSHAPE_M[typeof(trait)]]
+        else
+            SHAPECODE[TRAITSHAPE[typeof(trait)]]
+        end
+    end
+
+    # @assert bytes == io.size "The hardcoded accumulation of bytes $bytes should match how much bytes it has written into the buffer $(io.size)"
+
+    # Write the main block of data into the rest of the shape file
+    for (num, geom) in enumerate(geoms)
+        (trait === Missing || trait === GI.geomtrait(geom)) || throw(ArgumentError("Shapefiles can only contain geometries of the same type"))
+        # One-based record number; Increment from 0, and increment after record.
+        rec_bytes = Base.write(io, bswap(Int32(num)))
+        calc_recbytes = sizeof(Int32) # shape code
+
+        if ismissing(geom)
+            rec_bytes += Base.write(io, bswap(Int32(calc_recbytes)))
+            rec_bytes += Base.write(io, SHAPECODE[Missing])
+            bytes += rec_bytes
+            content_size += rec_bytes
+
+            # Indices for .shx file
+            offset = bytes ÷ 2
+            push!(shx_indices, IndexRecord(offset, rec_bytes))
+            continue
+        end
+
+        if trait isa GI.PointTrait 
+            calc_recbytes += sizeof(Float64) * 2 # point values
+            if hasz
+                calc_recbytes += sizeof(Float64) # z values
+            end
+            if hasm
+                calc_recbytes += sizeof(Float64) # measures
+            end
+        else
+            # box = read(io, Rect)
+            # numpoints = read(io, Int32)
+            # points = _readpoints(io, numpoints)
+
+            n = GI.npoint(geom)
+            calc_recbytes += sizeof(Rect) # Rect
+            calc_recbytes += sizeof(Int32) # num points
+            calc_recbytes += sizeof(Float64) * n * 2 # point values
+            if hasz
+                calc_recbytes += sizeof(Interval) # z interval
+                calc_recbytes += sizeof(Float64) * n # z values
+            end
+            if hasm
+                calc_recbytes += sizeof(Interval) # m interval
+                calc_recbytes += sizeof(Float64) * n # measures
+            end
+            numparts = _nparts(trait, geom) 
+            if !isnothing(numparts)
+                calc_recbytes += sizeof(Int32) # num parts
+                calc_recbytes += sizeof(Int32) * numparts # parts offsets
+            end
+        end
+
+        # Writing
+        #
+        # length
+        # measured in 16 bit increments, so divid by 2
+        rec_bytes += Base.write(io, bswap(Int32(calc_recbytes ÷ 2)))
+        # code
+        rec_bytes += Base.write(io, shapecode)
+        # geometry
+        geom_bytes, geom_mbr, geom_zrange, geom_mrange = _write(io, trait, geom)
+        rec_bytes += geom_bytes
+
+        if first_geom
+            first_geom = false
+            mbr = geom_mbr
+            zrange = geom_zrange
+            mrange = geom_mrange
+        else
+            mbr = union(mbr, geom_mbr)
+            zrange = union(zrange, geom_zrange)
+            mrange = union(mrange, geom_mrange)
+        end
 
         # Record Header
         # 32-bits (4 bytes) Record Number + 32-bits (4 bytes) Content length = 8 bytes
-        rec_length = bytes + 8 
-        write( geometries_io, bswap(Int32(num)))
-        
-        # Record length measured in 16-bit words (1-unit is 2-bytes (16-bits))
-        # So we divide record length recorded in bytes (8-bits) by 2 into 1 unit (16-bit/2 bytes) 
-        write( geometries_io, bswap(Int32(bytes /2)))
-        write( geometries_io, take!(record_io))
-        
-        content_size += rec_length
+        bytes += rec_bytes
+        content_size += rec_bytes
 
-        # !TODO: Here is where we extract and store the shx file content offset number        
-
-         
+        # Indices for .shx file
+        offset = bytes ÷ 2
+        push!(shx_indices, IndexRecord(offset, rec_bytes)) # TODO div by 2??
     end
 
-    # 
-    # Generate Basic File header information
-    #
-    code        = 9994
-    file_length = content_size + 100 
-    version     = 1000
-    
-    #
-    # Compute Shape-dependent information
-    #   1. MBR; Minimul Bounding Region, a up-right rectangular lat,lon box encapsulating all data point. 
-    #   2. zrange; An 1-dimensional interval encapsulating all z-values presented in the data 
-    #   3. mrange; An 1-dimensional interval encapsulating all measurements values presented in the data
-    #
-    MBR = get_MBR(shapes)
-    zrange = get_zrange(shapes)
-    mrange = get_mrange(shapes)
+    @assert bytes == content_size + header_bytes "The hardcoded accumulation of bytes $(content_size + header_bytes) should match how much bytes it has written into the buffer $bytes"
 
-    #
-    # Write File Header Information into file
-    #
-    bytes = 0
-    bytes += write(io, bswap(Int32(code)))
-    # code = bswap(read(io, Int32))
+    # Finally write the correct header at the start of the file
+    header = Header(; filesize=bytes ÷ 2, shapecode, mbr, zrange, mrange)
+    seek(io, 0)
+    Base.write(io, header)
+    
+    # Write .shx file
+    index_handle = IndexHandle(header, shx_indices)
+    Base.write(paths.shx, index_handle)
+    close(io)
 
-    bytes += write(io, Int32[0,0,0,0,0])
-    # read!(io, Vector{Int32}(undef, 5))
-    
-    # !NOTE: Record in 16-bits words
-    bytes += write(io, bswap(Int32(file_length/2)))
-    # content_size = bswap(read(io, Int32))
-    
-    bytes += write(io, Int32(version))
-    # version = read(io, Int32)
-
-    bytes += write(io, Int32(shapeType))
-    # shapeType = read(io, Int32)
-    
-    bytes += write(io, MBR)
-    # MBR = read(io, Rect)
-    
-    bytes += write(io, zrange.left)
-    bytes += write(io, zrange.right)
-    # zmin = read(io, Float64)
-    # zmax = read(io, Float64)
-    
-    bytes += write(io, mrange.left)
-    bytes += write(io, mrange.right)
-    # mmin = read(io, Float64)
-    # mmax = read(io, Float64)
-
-
-    
-    # Write the maind block of data into the rest of the shape file
-    write(io, take!(geometries_io))
-    
+    return bytes
 end
+
+_write(io::IO, geom; kw...) = _write(io::IO, GI.geomtrait(geom), geom; kw...)
+function _write(io::IO, ::Nothing, obj; kw...)
+    throw(ArgumentError("trying to write an object that is not a geometry: $(typeof(obj))"))
+end
+function _write(io::IO, trait::GI.AbstractGeometryTrait, geom; kw...)
+    bytes = Int64(0)
+    mbr = _calc_mbr(geom)
+    bytes += Base.write(io, mbr)
+    numparts = _nparts(trait, geom)
+    if !isnothing(numparts)
+        bytes += Base.write(io, numparts)
+    end
+    numpoints = Int32(GI.npoint(geom))
+    bytes += Base.write(io, numpoints)
+
+    # Polygons list ring start locations as "parts"
+    if !isnothing(numparts)
+        offset = Int32(0)
+        for part in _get_parts(trait, geom)
+            bytes += Base.write(io, offset)
+            offset += Int32(GI.npoint(part))
+        end
+    end
+    bytes += _write_xy(io, geom)
+    b, zrange, mrange = _write_others(io, geom; kw...)
+    bytes += b
+
+    return bytes, mbr, zrange, mrange
+end
+function _write(io::IO, ::GI.PointTrait, point;
+    hasz=GI.is3d(point), hasm=GI.ismeasured(point) 
+)
+    bytes = Int64(0)
+    x, y = Float64(GI.x(point)), Float64(GI.y(point))
+    mbr = Rect(x, y, x, y)
+    bytes += Base.write(io, x, y)
+    if hasz
+        z = Float64(GI.z(point))
+        bytes += Base.write(io, z)
+        zrange = Interval(z, z)
+    else
+        zrange = Interval(0.0, 0.0)
+    end
+    if hasm
+        m = Float64(GI.m(point))
+        bytes +=  Base.write(io, m)
+        mrange = Interval(m, m)
+    else
+        mrange = Interval(0.0, 0.0)
+    end
+
+    return bytes, mbr, zrange, mrange
+end
+
+function _calc_mbr(geom)
+    low_x = low_y = Inf
+    high_x = high_y = -Inf
+    for point in GI.getpoint(geom)
+        x, y = GI.x(point), GI.y(point)
+        low_x = min(low_x, x)
+        high_x = max(high_x, x)
+        low_y = min(low_y, y)
+        high_y = max(high_y, y)
+    end
+    return Rect(low_x, low_y, high_x, high_y)
+end
+
+function _write_xy(io, geom)
+    bytes = 0
+    for point in GI.getpoint(geom)
+        x, y = GI.x(point), GI.y(point)
+        bytes += Base.write(io, x)
+        bytes += Base.write(io, y)
+    end
+    return bytes
+end
+
+# z and m values are written separately if they exist
+function _write_others(io, geom;
+    hasz=GI.is3d(geom), hasm=GI.ismeasured(geom)
+)
+    bytes = 0
+    # TODO what to do when hasm == false but hasz == true
+    if hasz
+        b, zrange = _write_others(GI.z, io, geom)
+        bytes += b
+    else
+        zrange = Interval(0.0, 0.0)
+    end
+
+    if hasm 
+        b, mrange = _write_others(GI.m, io, geom)
+        bytes += b
+    else
+        mrange = Interval(0.0, 0.0)
+    end
+    return bytes, zrange, mrange
+end
+function _write_others(f, io, geom)
+    low = Inf
+    high = -Inf
+    for point in GI.getpoint(geom)
+        m = f(point)
+        low = min(low, m)
+        high = max(high, m)
+    end
+    range = Interval(low, high)
+    bytes = Base.write(io, range) 
+    for point in GI.getpoint(geom)
+        m = f(point)
+        bytes += Base.write(io, m)
+    end
+    return bytes, range
+end
+
+# Internal trait for shapes that track `parts` data
+_nparts(trait, geom) = nothing
+_nparts(trait::Union{GI.MultiPolygonTrait,GI.PolygonTrait}, geom) = Int32(GI.nring(geom))
+_nparts(trait::GI.MultiLineStringTrait, geom) = Int32(GI.nlinestring(geom))
+
+_get_parts(trait::Union{GI.MultiPolygonTrait,GI.PolygonTrait}, geom) = GI.getring(trait, geom)
+_get_parts(trait, geom) = GI.getgeom(trait, geom)

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -438,8 +438,9 @@ function Base.write(io::IO, ::Type{Handle}, shapes::Array{Union{Missing,T}}) whe
     bytes += write(io, mrange.right)
     # mmin = read(io, Float64)
     # mmax = read(io, Float64)
-    @show bytes
 
+
+    
     # Write the maind block of data into the rest of the shape file
     write(io, take!(geometries_io))
     

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -70,8 +70,7 @@ function write(path::AbstractString, obj; force=false)
         GI.isgeometry(geom1) || error("$(typeof(geom1)) is not a geometry")
         trait = GI.geomtrait(geom1)
         if trait isa GI.GeometryCollectionTrait 
-            @warn "Geometry Collections or MultiPatch cannot be written using Shapefile.jl"
-            return nothing
+            throw(ArgumentError("Geometry collections or `MultiPatch` cannot currently be written using Shapefile.jl"))
         end
         hasz = GI.is3d(geom1)
         hasm = GI.ismeasured(geom1)
@@ -94,10 +93,10 @@ function write(path::AbstractString, obj; force=false)
         calc_rec_bytes = sizeof(Int32) # shape code
 
         # Write record number
-        bytes += Base.write(io, bswap(Int32(num)))
+        bytes += Base.write(io, hton(Int32(num)))
 
         if ismissing(geom)
-            bytes += Base.write(io, bswap(Int32(calc_rec_bytes ÷ 2)))
+            bytes += Base.write(io, hton(Int32(calc_rec_bytes ÷ 2)))
             rec_bytes += Base.write(io, SHAPECODE[Missing])
 
             # Indices for .shx file
@@ -140,7 +139,7 @@ function write(path::AbstractString, obj; force=false)
         end
 
         # length: measured in 16 bit increments, so divid by 2
-        bytes += Base.write(io, bswap(Int32(calc_rec_bytes ÷ 2)))
+        bytes += Base.write(io, hton(Int32(calc_rec_bytes ÷ 2)))
         # code
         rec_bytes += Base.write(io, shapecode)
         # geometry

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -24,9 +24,9 @@ function write(path::AbstractString, obj; force=false)
 
     # Handle tabular data
     if Tables.istable(obj)
-        geomcol = GI.geometrycolumn(obj)
+        geomcol = first(GI.geometrycolumns(obj))
         geoms = Tables.getcolumn(obj, geomcol)
-        @warn "DBFTables.jl does not yet `write`, so no .dbx file can be written"
+        @warn "DBFTables.jl does not yet `write`, so only .shp and .shx file can be written"
         # DBFTables.Table(obj) # TODO remove geom column
         # DBFTables.write # TODO DBF write function
     else

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -45,7 +45,7 @@ function write(path::AbstractString, obj; force=false)
     # Open the .shp file as an IO stream
     io = open(paths.shp, "a+")
 
-    # Write an emtpy header 
+    # Write an empty header 
     # We go back later and write it properly later, so we don't have to precalculate everything.
     dummy_header = Header(; filesize=0, shapecode, mbr, zrange, mrange)
     bytes += Base.write(io, dummy_header)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,7 @@ test_tuples = [
         extent=Extent(X=(0.0, 10.0), Y=(0.0, 20.0), Z=(0.0, 0.0)),
         # This data has no shape, the correct bbox should be all zeros.
         # However the data contain some non-zero box values
-        skip_check_mask = [43:44,51:52,59:60,67:68],
+        skip_check_mask = [43:44..., 51:52..., 59:60..., 67:68...],
     ),(
         path=joinpath("shapelib_testcases", "test1.shp"),
         geomtype=Point,
@@ -86,9 +86,8 @@ test_tuples = [
         path=joinpath("shapelib_testcases/test13.shp"),
         geomtype=MultiPatch,
         coordinates=nothing,
-        # MultiPatch is currently coded with no mrange, but the test data has `mrange.right` as 27.35,
-        # However the writer output 0.0 as it can not possibily guess a random number that the test data has.
-        skip_check_mask = [93:100],
+        extent=Extent(X=(0.0, 100.0), Y=(0.0, 100.0), Z=(0.0, 27.35)),
+        skip_check_mask = 93:100,
     )
 ]
 
@@ -186,7 +185,7 @@ for test in test_tuples
             @test GeoInterface.coordinates.(shp.shapes) == test.coordinates
         end
         ext = test.extent
-        @test shp.MBR == Shapefile.Rect(ext.X[1], ext.Y[1], ext.X[2], ext.Y[2])
+        @test shp.header.MBR == Shapefile.Rect(ext.X[1], ext.Y[1], ext.X[2], ext.Y[2])
         @test GeoInterface.extent(shp) == test.extent
         # Multipatch can't be plotted, but it's obscure anyway
         if !(test.geomtype == Shapefile.MultiPatch)
@@ -233,7 +232,7 @@ for test in test_tuples
             shx = read(fd, Shapefile.IndexHandle)
             for sIdx = 1:lastindex(shx.indices)
                 @test shx.indices[sIdx].offset * 2 == offsets[sIdx]
-                @test shx.indices[sIdx].contentLen * 2 + 8 == contentlens[sIdx]
+                @test shx.indices[sIdx].contentlen * 2 + 8 == contentlens[sIdx]
             end
         end
 
@@ -243,3 +242,4 @@ end  # @testset "Loading Shapefiles"
 
 include("table.jl")
 include("writer.jl")
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,9 @@ test_tuples = [
         geomtype=Missing,
         coordinates=nothing,
         extent=Extent(X=(0.0, 10.0), Y=(0.0, 20.0), Z=(0.0, 0.0)),
+        # This data has no shape, the correct bbox should be all zeros.
+        # However the data contain some non-zero box values
+        skip_check_mask = [43:44,51:52,59:60,67:68],
     ),(
         path=joinpath("shapelib_testcases", "test1.shp"),
         geomtype=Point,
@@ -83,7 +86,9 @@ test_tuples = [
         path=joinpath("shapelib_testcases/test13.shp"),
         geomtype=MultiPatch,
         coordinates=nothing,
-        extent=Extent(X=(0.0, 100.0), Y=(0.0, 100.0), Z=(0.0, 27.35)),
+        # MultiPatch is currently coded with no mrange, but the test data has `mrange.right` as 27.35,
+        # However the writer output 0.0 as it can not possibily guess a random number that the test data has.
+        skip_check_mask = [93:100],
     )
 ]
 
@@ -237,3 +242,4 @@ end
 end  # @testset "Loading Shapefiles"
 
 include("table.jl")
+include("writer.jl")

--- a/test/table.jl
+++ b/test/table.jl
@@ -40,6 +40,14 @@ ne_land = Shapefile.Table(path(natural_earth, "ne_land_shp"))
 ne_coastline = Shapefile.Table(path(natural_earth, "ne_coastline_shp"))
 ne_cities = Shapefile.Table(path(natural_earth, "ne_cities_shp"))
 
+@testset "write tables" begin
+    Shapefile.write("cities_write", ne_cities; force=true)
+    @test_throws ArgumentError Shapefile.Table("cities_write")
+    written = Shapefile.Handle("cities_write.shp")
+    shp = Shapefile.Handle(path(natural_earth, "ne_cities_shp"))
+    @test written.shapes == shp.shapes
+end
+
 @testset "Create from parts" begin
     ne_land_shp = open(path(natural_earth, "ne_land_shp")) do io
         read(io, Shapefile.Handle)

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -4,35 +4,44 @@
 
 @testset "Shapefile (.shp) writers" begin
 
-
-for test in test_tuples
-    
+for i in eachindex(test_tuples)[1:end-1] # We dont write 15 - multipatch
     #
     # Read the shapefile into memory and write it into a temporary IO buffer
     #
-    shp = open(joinpath(@__DIR__, test.path)) do fd
-        read(fd, Shapefile.Handle)
+    test = test_tuples[i]
+    path = joinpath(@__DIR__, test.path)
+    shp = Shapefile.Handle(path)
+    Shapefile.write("testshape", shp.shapes; force=true)
+    fieldnames(Shapefile.Header)
+    @testset "compare headers" begin
+        h1 = read("testshape.shp", Shapefile.Header)
+        h2 = read(path, Shapefile.Header)
+        if !haskey(test, :skip_check_mask)
+            @test h1 == h2
+        end
     end
-    test_io = IOBuffer()
-    write(test_io, Shapefile.Handle, shp.shapes)
-    test_bytes = take!(test_io)
-
-    # Read the original file as bytes for byte-to-byte comparison
-    match_bytes = open(joinpath(@__DIR__, test.path)) do fd
-        read(fd)
+    @testset "compare bytes" begin
+        r1 = read("testshape.shp")
+        r2 = read(path)
+        if haskey(test, :skip_check_mask)
+            inds = map(eachindex(r1)) do i 
+                !(i in test.skip_check_mask)
+            end
+            r1[inds] == r2[inds]
+        else
+            findall(r1 .!= r2)
+            @test r1 == r2
+        end
     end
-    
-    #
-    # Load in some testing exception, because the test data is partially invalid.
-    #
-    if haskey(test,:skip_check_mask)
-        for idc in test.skip_check_mask
-            match_bytes[idc] .= 0
-            test_bytes[idc] .= 0
-        end 
+    @testset "compare points" begin
+        shp1 = Shapefile.Handle(path)
+        shp2 = Shapefile.Handle("testshape.shp")
+        shp1.shapes
+        shp2.shapes
+        @test all(map(shp1.shapes, shp2.shapes) do s1, s2
+            ismissing(s1) && ismissing(s2) || s1 == s2
+        end)
     end
-
-    @test all(test_bytes .== match_bytes)    
 end
 
 end

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -41,7 +41,6 @@ for i in eachindex(test_tuples)[1:end-1] # We dont write 15 - multipatch
         shp1 = Shapefile.Handle(path)
         shp2 = Shapefile.Handle("testshape.shp")
         shp3 = Shapefile.Handle("testshape.shp", "testshape.shx")
-        # shp2 = Shapefile.Handle("testshape.shp", "testshape.shx")
         @test all(map(shp1.shapes, shp2.shapes) do s1, s2
             ismissing(s1) && ismissing(s2) || s1 == s2
         end)

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -5,22 +5,26 @@
 @testset "Shapefile (.shp) writers" begin
 
 for i in eachindex(test_tuples)[1:end-1] # We dont write 15 - multipatch
-    #
-    # Read the shapefile into memory and write it into a temporary IO buffer
-    #
+
     test = test_tuples[i]
     path = joinpath(@__DIR__, test.path)
     shp = Shapefile.Handle(path)
     Shapefile.write("testshape", shp.shapes; force=true)
-    fieldnames(Shapefile.Header)
-    @testset "compare headers" begin
+    
+    @testset "shx indices match" begin
+        ih1 = read(Shapefile._shape_paths(path).shx, Shapefile.IndexHandle)
+        ih2 = read(Shapefile._shape_paths("testshape").shx, Shapefile.IndexHandle)
+        @test ih1.indices == ih2.indices
+    end
+    @testset "shp headers match" begin
         h1 = read("testshape.shp", Shapefile.Header)
         h2 = read(path, Shapefile.Header)
+        h3 = read(Shapefile._shape_paths("testshape").shx, Shapefile.Header)
         if !haskey(test, :skip_check_mask)
-            @test h1 == h2
+            @test h1 == h2 == h3
         end
     end
-    @testset "compare bytes" begin
+    @testset "shp bytes match" begin
         r1 = read("testshape.shp")
         r2 = read(path)
         if haskey(test, :skip_check_mask)
@@ -33,11 +37,11 @@ for i in eachindex(test_tuples)[1:end-1] # We dont write 15 - multipatch
             @test r1 == r2
         end
     end
-    @testset "compare points" begin
+    @testset "shapes match" begin
         shp1 = Shapefile.Handle(path)
         shp2 = Shapefile.Handle("testshape.shp")
-        shp1.shapes
-        shp2.shapes
+        shp3 = Shapefile.Handle("testshape.shp", "testshape.shx")
+        # shp2 = Shapefile.Handle("testshape.shp", "testshape.shx")
         @test all(map(shp1.shapes, shp2.shapes) do s1, s2
             ismissing(s1) && ismissing(s2) || s1 == s2
         end)

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -1,0 +1,38 @@
+#
+# Unit Testing for Shapefile writer
+#
+
+@testset "Shapefile (.shp) writers" begin
+
+
+for test in test_tuples
+    
+    #
+    # Read the shapefile into memory and write it into a temporary IO buffer
+    #
+    shp = open(joinpath(@__DIR__, test.path)) do fd
+        read(fd, Shapefile.Handle)
+    end
+    test_io = IOBuffer()
+    write(test_io, Shapefile.Handle, shp.shapes)
+    test_bytes = take!(test_io)
+
+    # Read the original file as bytes for byte-to-byte comparison
+    match_bytes = open(joinpath(@__DIR__, test.path)) do fd
+        read(fd)
+    end
+    
+    #
+    # Load in some testing exception, because the test data is partially invalid.
+    #
+    if haskey(test,:skip_check_mask)
+        for idc in test.skip_check_mask
+            match_bytes[idc] .= 0
+            test_bytes[idc] .= 0
+        end 
+    end
+
+    @test all(test_bytes .== match_bytes)    
+end
+
+end


### PR DESCRIPTION
This is a rehash of #34, but working with any GeoInterface.jl geometries, lazily.

I feel that Shapefile.jl should cover the spaces that GDAL fails, which is reading and writing very large datasets quickly. 

(You could probably write a larger than-memory mmaped GeoJSON.jl file to a shapefile with this, if you only had 2GB RAM and sanity didn't prevail first)

Any stress testing and feedback would be good at this stage. 


Note: there is a bunch of seemingly unrelated new code/changes for 
1. reusing file header read/write between shp and shx files - its the same header in both
2. equality comparisons of geoms here. It's useful for testing and may as well work.

This just made writing the PR easier.