### PR TITLE
Fix getproperty(Row, :geometry)

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -16,7 +16,13 @@ struct Row{T}
 end
 
 
-Base.getproperty(row::Row, name::Symbol) = getproperty(getfield(row, :record), name)
+function Base.getproperty(row::Row, name::Symbol)
+    if name == :geometry
+        return getfield(row, :geometry)
+    else
+        return getproperty(getfield(row, :record), name)
+    end
+end
 Base.propertynames(row::Row) = propertynames(getfield(row, :record))
 
 GeoInterface.isfeature(t::Row) = true

--- a/test/table.jl
+++ b/test/table.jl
@@ -86,6 +86,7 @@ wkt = "GEOGCS[\"GCS_WGS_1984\",DATUM[\"D_WGS_1984\",SPHEROID[\"WGS_1984\",637813
     @test count(true for r in ne_land) == length(ne_land)
     @test propertynames(ne_land) == [:geometry, :featurecla, :scalerank, :min_zoom]
     @test propertynames(first(ne_land)) == [:featurecla, :scalerank, :min_zoom]
+    @test first(ne_land).geometry isa Shapefile.Polygon
     @test ne_land.featurecla isa Vector{String}
     @test length(ne_land.scalerank) == length(ne_land)
     @test GeoInterface.crs(ne_land) == GeoFormatTypes.ESRIWellKnownText(GeoFormatTypes.CRS(), wkt)
@@ -117,6 +118,7 @@ end
     @test count(true for r in ne_coastline) == length(ne_coastline)
     @test propertynames(ne_coastline) == [:geometry, :scalerank, :featurecla, :min_zoom]
     @test propertynames(first(ne_coastline)) == [:scalerank, :featurecla, :min_zoom]
+    @test first(ne_coastline).geometry isa Shapefile.Polyline
     @test ne_coastline.featurecla isa Vector{String}
     @test GeoInterface.crs(ne_coastline) == GeoFormatTypes.ESRIWellKnownText(GeoFormatTypes.CRS(), wkt)
     @test length(ne_coastline.scalerank) == length(ne_coastline)
@@ -154,6 +156,7 @@ end
     ]
     @test propertynames(ne_cities) == colnames
     @test propertynames(first(ne_cities)) == colnames[2:end]
+    @test first(ne_cities).geometry isa Shapefile.Point
     @test ne_cities.featurecla isa Vector{String}
     @test GeoInterface.crs(ne_coastline) == GeoFormatTypes.ESRIWellKnownText(GeoFormatTypes.CRS(), wkt)
     @test length(ne_cities.scalerank) == length(ne_cities)


### PR DESCRIPTION
This change allows to access the geometry of a Shapefile.Row via Row.geometry.
This PR fixes #82. 
This change is also needed so that Tables.columns of a collection of Shapefile.Row works (which you can end up with when filtering a Shapefile by some column values).

Why is Base.propertynames(Row) overloaded so that it doesn't also show the `:geometry` column?
I thought about also changing that, but it is actively tested for, therefore I was hesitant to change it. 



