### PR TITLE
remove convert methods

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -4,11 +4,6 @@ abstract type AbstractShape end
 GeoInterface.isgeometry(::Type{<:AbstractShape}) = true
 GeoInterface.ncoord(::GI.AbstractGeometryTrait, ::AbstractShape) = 2 # With specific methods when 3
 
-Base.convert(T::Type{<:AbstractShape}, geom) = Base.convert(T, GI.geomtrait(geom), geom)
-Base.convert(::Type{T}, geom::T) where {T<:AbstractShape} = geom
-Base.convert(::Type{<:AbstractShape}, ::Nothing, geom) =
-    throw(ArgumentError("object to convert is not a GeoInterface compatible geometry"))
-
 """
     Rect
 

--- a/src/multipoints.jl
+++ b/src/multipoints.jl
@@ -1,11 +1,6 @@
 
 abstract type AbstractMultiPoint{T} <: AbstractShape end
 
-_pointtype(::Type{<:AbstractMultiPoint{T}}) where T = T
-
-Base.convert(::Type{T}, ::GI.MultiPointTrait, geom) where T<:AbstractMultiPoint =
-    T(_convert(_pointtype(T), geom)...)
-
 GI.geomtrait(::AbstractMultiPoint) = GI.MultiPointTrait()
 GI.ngeom(::GI.MultiPointTrait, geom::AbstractMultiPoint) = length(geom.points)
 GI.ncoord(::GI.MultiPointTrait, geom::AbstractMultiPoint{T}) where {T} = _ncoord(T)

--- a/src/points.jl
+++ b/src/points.jl
@@ -27,8 +27,6 @@ function Base.read(io::IO, ::Type{Point})
     Point(x, y)
 end
 
-Base.convert(::Type{<:Point}, ::GI.PointTrait, geom) = Point(GI.x(geom), GI.y(geom))
-
 """
     PointM <: AbstractPoint
 
@@ -50,11 +48,6 @@ function Base.read(io::IO, ::Type{PointM})
     y = read(io, Float64)
     m = read(io, Float64)
     PointM(x, y, m)
-end
-
-function Base.convert(::Type{<:PointM}, ::GI.PointTrait, geom)
-    m = GI.ismeasured(geom) ? GI.m(geom) : 0.0
-    PointM(GI.x(geom), GI.y(geom), m)
 end
 
 GI.m(::GI.PointTrait, point::PointM) = point.m
@@ -82,12 +75,6 @@ function Base.read(io::IO, ::Type{PointZ})
     z = read(io, Float64)
     m = read(io, Float64)
     PointZ(x, y, z, m)
-end
-
-function Base.convert(::Type{<:PointZ}, ::GI.PointTrait, geom)
-    z = GI.is3d(geom) ? GI.z(geom) : 0.0
-    m = GI.ismeasured(geom) ? GI.m(geom) : 0.0
-    PointZ(GI.x(geom), GI.y(geom), z, m)
 end
 
 GI.m(::GI.PointTrait, point::PointZ) = point.m

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -48,11 +48,6 @@ abstract type AbstractPolygon{T} <: AbstractShape end
 _hasparts(::GI.MultiPolygonTrait) = true
 _hasparts(::GI.PolygonTrait) = true
 
-_pointtype(::Type{<:AbstractPolygon{T}}) where T = T
-
-Base.convert(::Type{T}, ::GI.MultiPolygonTrait, geom) where T<:AbstractPolygon =
-    T(_convertparts(_pointtype(T), geom)...)
-
 # Shapefile polygons are OGC multipolygons
 GI.geomtrait(geom::AbstractPolygon) = GI.MultiPolygonTrait()
 GI.nring(::GI.MultiPolygonTrait, geom::AbstractPolygon) = length(geom.parts)

--- a/src/polylines.jl
+++ b/src/polylines.jl
@@ -26,11 +26,6 @@ abstract type AbstractPolyline{T} <: AbstractShape end
 
 _hasparts(::GI.MultiLineStringTrait) = true
 
-_pointtype(::Type{<:AbstractPolyline{T}}) where T = T
-
-Base.convert(::Type{T}, ::GI.MultiLineStringTrait, geom) where T<:AbstractPolyline =
-    T(_convertparts(_pointtype(T), geom)...)
-
 GI.geomtrait(::AbstractPolyline) = GI.MultiLineStringTrait()
 GI.ngeom(::GI.MultiLineStringTrait, geom::AbstractPolyline) = length(geom.parts)
 GI.ncoord(::GI.MultiLineStringTrait, ::AbstractPolyline{T}) where {T} = _ncoord(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Shapefile
 using GeoFormatTypes
 using Test
 
-GI = GeoInterface
+const GI = GeoInterface
 
 
 using Shapefile: Point, PointM, PointZ, Polygon, PolygonM, PolygonZ, Polyline,
@@ -137,39 +137,6 @@ test_shapes = Dict(
 @testset "GeoInterface compatability" begin
     @test all(s -> GeoInterface.testgeometry(s), values(test_shapes))
     @test_broken GeoInterface.testgeometry(MultiPatch(Rect(1, 3, 2, 4), [0], [1], points, Interval(1, 4), [1, 2, 3, 4]))
-end
-
-@testset "convert" begin
-    @test convert(Point, PointZ(1, 2, 3, 4)) == Point(1, 2)
-    @test convert(PointM, PointZ(1, 2, 3, 4)) == PointM(1, 2, 4)
-    @test convert(PointZ, Point(1, 2)) == PointZ(1, 2, 0, 0)
-    pl = convert(Polyline, test_shapes[PolylineZ])
-    @test pl.MBR == test_shapes[Polyline].MBR
-    @test pl.points == test_shapes[Polyline].points
-    pl = convert(PolylineM, test_shapes[PolylineZ])
-    @test pl.MBR == test_shapes[PolylineM].MBR
-    @test pl.points == test_shapes[PolylineM].points
-    @test pl.measures == test_shapes[PolylineM].measures
-    pg = convert(Polygon, test_shapes[PolygonZ])
-    @test pg.MBR == test_shapes[Polygon].MBR
-    @test pg.points == test_shapes[Polygon].points
-    pg = convert(PolygonM, test_shapes[PolygonZ])
-    @test pg.MBR == test_shapes[PolygonM].MBR
-    @test pg.points == test_shapes[PolygonM].points
-    @test pg.measures == test_shapes[PolygonM].measures
-    mp = convert(MultiPoint, test_shapes[MultiPointZ])
-    @test mp.MBR == test_shapes[MultiPoint].MBR
-    @test mp.points == test_shapes[MultiPoint].points
-    mp = convert(MultiPointM, test_shapes[MultiPointZ])
-    @test mp.MBR == test_shapes[PolylineM].MBR
-    @test mp.points == test_shapes[PolylineM].points
-    @test mp.measures == test_shapes[PolylineM].measures
-
-    mp = convert(MultiPointZ, test_shapes[MultiPointM])
-    @test mp.MBR == test_shapes[PolylineZ].MBR
-    @test mp.points == test_shapes[PolylineZ].points
-    @test mp.measures == test_shapes[PolylineM].measures
-    @test mp.zvalues == [0.0, 0.0, 0.0, 0.0]  # Missing Z filled with zeros: is this the best default?
 end
 
 @testset "Loading Shapefiles" begin


### PR DESCRIPTION
I went to start rewriting `convert` for GeoInterface but it just doesn't make sense to convert to these objects. We can write any geointerface geometries to shapefile anyway now, and it's a useless format for intermediate use. So its better to not maintain this code.

So this PR just removes all the convert methods.