### PR TITLE
use shx files if the names match

### DIFF
--- a/src/handle.jl
+++ b/src/handle.jl
@@ -15,7 +15,15 @@ mutable struct Handle{T<:Union{<:AbstractShape,Missing}}
     shapes::Vector{T}
     crs::Union{Nothing, GFT.ESRIWellKnownText{GFT.CRS}}
 end
-function Handle(path::AbstractString, index=nothing)
+function Handle(path::AbstractString)
+    shx = splitext(path)[1] * ".shx"
+    if isfile(shx)
+        Handle(path, shx)
+    else
+        Handle(path, nothing)
+    end
+end
+function Handle(path::AbstractString, index)
     open(path) do io
         read(io, Handle, index; path = path)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,12 +163,14 @@ end
 @testset "Loading Shapefiles" begin
 
 for test in test_tuples
-    for use_shx in (false, true)
-        shp = if use_shx
+    for shx in (:manual, :auto, :none)
+        shp = if shx == :manual
             # this accesses .shp based on offsets in .shx
             stempath, ext = splitext(test.path)
             shxname = string(stempath, ".shx")
             Shapefile.Handle(joinpath(@__DIR__, test.path), joinpath(@__DIR__, shxname))
+        elseif shx == :auto
+            Shapefile.Handle(joinpath(@__DIR__, test.path))
         else
             # use .shp only
             open(joinpath(@__DIR__, test.path)) do fd


### PR DESCRIPTION
Seems like this should work by default, is there a reason it doesn't?