### PR TITLE
Add support for writing Feature Collection without properties

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
           - windows-latest
         arch:
           - x64
+        # tests are not working on Windows with Julia 1.9
         exclude:
           - os: windows-latest
             version: '1.9'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          - '1.9'
+          # - '1.9'
           - '1'
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # - windows-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          # - '1.9'
+          - '1.9'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,9 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          - os: windows-latest
+            version: '1.9'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,12 +13,12 @@ jobs:
       fail-fast: true
       matrix:
         version:
-          - '1.9'
+          # - '1.9'
           - '1'
         os:
           - ubuntu-latest
           - macOS-latest
-          # - windows-latest
+          - windows-latest
         arch:
           - x64
     steps:

--- a/src/writer.jl
+++ b/src/writer.jl
@@ -60,7 +60,8 @@ function get_writer(obj)
     elseif GI.trait(obj) isa GI.AbstractFeatureCollectionTrait
         geoms = map(GI.geometry, GI.getfeature(obj))
         feats = Tables.dictcolumntable(map(GI.properties, GI.getfeature(obj)))
-        return Writer(geoms, feats, crs)
+        tbl = isempty(feats) ? emptytable(geoms) : feats
+        return Writer(geoms, tbl, crs)
     elseif Tables.istable(obj)
         tbl = getfield(Tables.dictcolumntable(obj), :values)  # an OrderedDict
         geomfields = findall(tbl) do data

--- a/test/writer.jl
+++ b/test/writer.jl
@@ -71,6 +71,18 @@
         @test t.one == [1, 1]
         @test t.two == [2, 2]
 
+        # feature collection without properties
+        struct NoProps end
+        feats = [(; geometry=Point(0,0)), (; geometry=Point(1,1))]
+        GI.geomtrait(::NoProps) = GI.FeatureCollectionTrait()
+        GI.isfeaturecollection(::NoProps) = true
+        GI.getfeature(::GI.FeatureCollectionTrait, ::NoProps, i) = feats[i]
+        GI.nfeature(::GI.FeatureCollectionTrait, ::NoProps) = length(feats)
+        file = tempname()
+        Shapefile.write(file, NoProps())
+        t = Shapefile.Table(file)
+        @test t.geometry == [Point(0,0), Point(1,1)]
+
         # table (with missing)
         tbl = [
             (geo=Point(0,0), feature=1),


### PR DESCRIPTION
Shapefile.jl breaks when writing a Feature Collection without properties.
MWE:
```
julia> import GeoJSON

julia> fc = GeoJSON.read("test.geojson")
FeatureCollection with 3 Features

julia> import Shapefile

julia> Shapefile.write("test.shp", fc)
ERROR: MethodError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer
Stacktrace:
  [1] reduce_empty(op::Base.MappingRF{Shapefile.var"#21#24", Base.BottomRF{…}}, ::Type{Tables.ColumnsRow{…}})
    @ Base ./reduce.jl:361
...
```
Contents of the `test.geojson` file:
```
{
    "type": "FeatureCollection",
    "features": [
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    0.0,
                    0.0
                ]
            },
            "properties": {}
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    1.0,
                    1.0
                ]
            },
            "properties": {}
        },
        {
            "type": "Feature",
            "geometry": {
                "type": "Point",
                "coordinates": [
                    2.0,
                    2.0
                ]
            },
            "properties": {}
        }
    ]
}
``` 