### PR TITLE
Polygon performance

### DIFF
--- a/src/extent.jl
+++ b/src/extent.jl
@@ -33,7 +33,8 @@ function GI.extent(::GI.AbstractGeometryTrait, x::AbstractShape)
     rect = x.MBR
     return Extents.Extent(X=(rect.left, rect.right), Y=(rect.bottom, rect.top))
 end
-function GI.extent(::GI.AbstractGeometryTrait, x::ShapeZ)
+# Need to remove LinearRing and SubPolygon from dispatch here to avoid ambiguity
+function GI.extent(::GI.AbstractGeometryTrait, x::Union{PolylineZ,PolygonZ,MultiPointZ,MultiPatch})
     rect = x.MBR
     return Extents.Extent(X=(rect.left, rect.right), Y=(rect.bottom, rect.top), Z=(x.zrange.left, x.zrange.right))
 end

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -98,7 +98,7 @@ function GI.getgeom(::GI.MultiPolygonTrait, geom::AbstractPolygon{T}) where {T}
         _build_cache!(geom)
     end
     return map(geom.indexcache) do indices
-        SubPolygon(GI.getring.(Ref(geom), indices)) 
+        SubPolygon(GI.getring.((geom,), indices)) 
     end
 end
 

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -94,7 +94,7 @@ function GI.getgeom(::GI.MultiPolygonTrait, geom::AbstractPolygon, i::Integer)
     return SubPolygon(rings)
 end
 function GI.getgeom(::GI.MultiPolygonTrait, geom::AbstractPolygon{T}) where {T}
-    if length(geom.indexcache) == 0
+    if isempty(geom.indexcache)
         _build_cache!(geom)
     end
     return map(geom.indexcache) do indices

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -201,8 +201,7 @@ function Base.read(io::IO, ::Type{Polygon})
     numpoints = read(io, Int32)
     parts = _readparts(io, numparts)
     points = _readpoints(io, numpoints)
-    indexcache = Vector{Bool}[]
-    Polygon(box, parts, points, indexcache)
+    Polygon(box, parts, points)
 end
 
 Base.:(==)(p1::Polygon, p2::Polygon) = (p1.parts == p2.parts) && (p1.points == p2.points)
@@ -240,8 +239,7 @@ function Base.read(io::IO, ::Type{PolygonM})
     parts = _readparts(io, numparts)
     points = _readpoints(io, numpoints)
     mrange, measures = _readm(io, numpoints)
-    indexcache = Vector{Bool}[]
-    PolygonM(box, parts, points, mrange, measures, indexcache)
+    PolygonM(box, parts, points, mrange, measures)
 end
 
 """
@@ -280,6 +278,5 @@ function Base.read(io::IO, ::Type{PolygonZ})
     points = _readpoints(io, numpoints)
     zrange, zvalues = _readz(io, numpoints)
     mrange, measures = _readm(io, numpoints)
-    indexcache = Vector{Bool}[]
-    PolygonZ(box, parts, points, zrange, zvalues, mrange, measures, indexcache)
+    PolygonZ(box, parts, points, zrange, zvalues, mrange, measures)
 end

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -83,8 +83,6 @@ function GI.getring(::GI.MultiPolygonTrait, geom::AbstractPolygon{P}, i::Integer
     LinearRing{P}(xy, z, m)
 end
 
-# Warning: getgeom is very slow for a Shapefile.
-# If you don't need exteriors and holes to be separated, use `getring`.
 function GI.getgeom(::GI.MultiPolygonTrait, geom::AbstractPolygon, i::Integer)
     if length(geom.indexcache) == 0
         _build_cache!(geom)

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -90,7 +90,7 @@ function GI.getgeom(::GI.MultiPolygonTrait, geom::AbstractPolygon, i::Integer)
         _build_cache!(geom)
     end
     indices = geom.indexcache[i]
-    rings = GI.getring.(Ref(GI.MultiPolygonTrait()), Ref(geom), indices)
+    rings = GI.getring.((GI.MultiPolygonTrait(),), (geom,), indices)
     return SubPolygon(rings)
 end
 function GI.getgeom(::GI.MultiPolygonTrait, geom::AbstractPolygon{T}) where {T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,6 +189,8 @@ for test in test_tuples
         # missing and MultiPatch are not covered by the GeoInterface
         if !(test.geomtype <: Union{Missing,Shapefile.MultiPatch})
             @test GeoInterface.coordinates.(shp.shapes) == test.coordinates
+            # Run this a second time to test caching
+            @test GeoInterface.coordinates.(shp.shapes) == test.coordinates
         end
         ext = test.extent
         @test shp.header.MBR == Shapefile.Rect(ext.X[1], ext.Y[1], ext.X[2], ext.Y[2])


### PR DESCRIPTION
For `Shapefile.Polygon` this PR speeds up looping over `GI.getgeom(poly, i)` by ~100x for the first run and ~1000x after that (for very large shape files at least!)

1. It caches the ring order as a `Vector{Vector{Int}}` and only calculates it on the first `getgeom`.
2. It checks `Extents.intersects` before actually checking `_inring` for another more modest speedup.

It specifically _does not_ eagerly fill the cache on construction, because some use cases don't need it, like `GI.getring` which returns them in the current order (which is 20x faster for e.g. calculating hulls or rasterization).

Users may also only want a subset of polygons, and this skips doing most of the work in that case.

@asinghvi17 if you want to review that would be great :)

(there is a tiny bit of type instability but this will be fixed in Extents.jl its just lack of inlining stopping const prop)