### PR TITLE
Describe what was found in the file extension when erroring

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,7 +58,7 @@ function _shape_paths(path)
     elseif ext == ""
         shp = string(stempath, ".shp")
     else
-        throw(ArgumentError("Provide the shapefile with either `.shp` or no extension"))
+        throw(ArgumentError("Provide the shapefile with either `.shp` or no extension.\nFound `$ext`."))
     end
 
     shx = string(stempath, ".shx")


### PR DESCRIPTION
This allows things like `".shp "` to get diagnosed more easily, since dragging a file on Mac produces this kind of string (with a space at the end).
